### PR TITLE
Restart pooler if service is running, but port is unavailable

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -120,7 +120,7 @@ class pgconsul(object):
             sys.exit(1)
 
         if self.db.is_alive() and not self.zk.is_alive():
-            if self.db.role == 'primary' and self.db.pgpooler('status'):
+            if self.db.role == 'primary' and self.db.pgpooler('status')[1]:
                 self.db.pgpooler('stop')
 
         if not self.db.is_alive() and self.zk.is_alive():
@@ -340,7 +340,12 @@ class pgconsul(object):
 
         self.zk.write(self.zk.TIMELINE_INFO_PATH, db_state['timeline'])
 
-        if not self.db.pgpooler('status'):
+        pooler_status, pooler_service_status = self.db.pgpooler('status')
+        if pooler_service_status and not pooler_status:
+            logging.warning('Service alive, but pooler not accepting connections, restarting.')
+            self.db.pgpooler('stop')
+            self.db.pgpooler('start')
+        elif not pooler_service_status:
             logging.debug('Here we should open for load.')
             self.db.pgpooler('start')
 
@@ -412,7 +417,12 @@ class pgconsul(object):
 
             self._drop_stale_switchover(db_state)
 
-            if not self.db.pgpooler('status'):
+            pooler_status, pooler_service_status = self.db.pgpooler('status')
+            if pooler_service_status and not pooler_status:
+                logging.warning('Service alive, but pooler not accepting connections, restarting.')
+                self.db.pgpooler('stop')
+                self.db.pgpooler('start')
+            elif not pooler_service_status:
                 logging.debug('Here we should open for load.')
                 self.db.pgpooler('start')
 
@@ -539,7 +549,7 @@ class pgconsul(object):
 
     def start_pooler(self):
         start_pooler = self.config.getboolean('replica', 'start_pooler')
-        if not self.db.pgpooler('status') and start_pooler:
+        if not self.db.pgpooler('status')[1] and start_pooler:
             self.db.pgpooler('start')
 
     def get_replics_info(self, zk_state):

--- a/src/pg.py
+++ b/src/pg.py
@@ -219,7 +219,7 @@ class Postgres(object):
             self.role = data['role']
             data['pg_version'] = self._get_pg_version()
             data['pgdata'] = self._get_pgdata_path()
-            data['opened'] = self.pgpooler('status')
+            data['opened'] = self.pgpooler('status')[1]
             data['timeline'] = self.get_data_from_control_file('Latest checkpoint.s TimeLineID', preproc=int, log=False)
             data['wal_receiver'] = self._get_wal_receiver_info()
 
@@ -564,11 +564,12 @@ class Postgres(object):
                 try:
                     sock = socket.create_connection((pooler_addr, pooler_port), pooler_conn_timeout)
                     sock.close()
-                    return True
+                    return True, True
                 except socket.error:
-                    return not bool(self._cmd_manager.get_pooler_status())
+                    return False, not bool(self._cmd_manager.get_pooler_status())
             else:
-                return not bool(self._cmd_manager.get_pooler_status())
+                res = not bool(self._cmd_manager.get_pooler_status())
+                return res, res
         elif action == 'start':
             if not bool(self._cmd_manager.get_pooler_status()):
                 return True


### PR DESCRIPTION
I know only one way to reproduce the situation when the port is unavailable, but the service is running - connect to the pooler via GDB.
In this case pgconsul works as expected with that patch. Calls systemctl stop, which kills the pooler after TimeoutStopSec. Then runs pooler again.