### PR TITLE
Better KazooTimeoutError handling

### DIFF
--- a/tests/features/pgconsul_util.feature
+++ b/tests/features/pgconsul_util.feature
@@ -702,7 +702,7 @@ Feature: Check pgconsul-util features
         """
         pgconsul-util initzk --test pgconsul_postgresql1_1.pgconsul_pgconsul_net pgconsul_postgresql2_1.pgconsul_pgconsul_net
         """
-        Then command exit with return code "1"
+        Then command exit with return code "2"
         And command result contains following output
         """
         KazooTimeoutError


### PR DESCRIPTION
https://kazoo.readthedocs.io/en/latest/api/interfaces.html#kazoo.interfaces.IAsyncResult.get

wait(timeout=X) - does not raise Kazoo Timeout Error when timeout occurs. 
So, for now, we assume that the write is successful even if we get a write timeout from ZK.