### PR TITLE
Better steps patterns

### DIFF
--- a/tests/features/autofailover.feature
+++ b/tests/features/autofailover.feature
@@ -45,7 +45,7 @@ Feature: Check pgconsul with disabled autofailover
         """
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql3" became a primary
@@ -55,7 +55,7 @@ Feature: Check pgconsul with disabled autofailover
         Then postgresql in container "postgresql1" was not rewinded
         Then container "postgresql1" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql3_1.pgconsul_pgconsul_net","timeline": 2}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql3_1.pgconsul_pgconsul_net','timeline': 2}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql1" became a primary
@@ -63,7 +63,7 @@ Feature: Check pgconsul with disabled autofailover
         And container "postgresql2" is a replica of container "postgresql1"
         When we stop container "postgresql2"
         And we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 3}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 3}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         And we wait "30.0" seconds

--- a/tests/features/kill_primary.feature
+++ b/tests/features/kill_primary.feature
@@ -110,7 +110,7 @@ Feature: Destroy primary in various scenarios
         """
         Then container "postgresql3" is a replica of container "postgresql2"
         Then postgresql in container "postgresql3" was not rewinded
-        Then <lock_type> "<lock_host>" has value "["pgconsul_postgresql3_1.pgconsul_pgconsul_net"]" for key "/pgconsul/postgresql/quorum"
+        Then <lock_type> "<lock_host>" has value "['pgconsul_postgresql3_1.pgconsul_pgconsul_net']" for key "/pgconsul/postgresql/quorum"
         When we <destroy> container "postgresql2"
         Then <lock_type> "<lock_host>" has holder "pgconsul_postgresql3_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         Then container "postgresql3" became a primary
@@ -346,7 +346,7 @@ Feature: Destroy primary in various scenarios
         When we stop container "postgresql3"
         When we drop replication slot "pgconsul_postgresql3_1_pgconsul_pgconsul_net" in container "postgresql1"
         When we start container "postgresql3"
-        Then <lock_type> "<lock_host>" has value "["pgconsul_postgresql2_1.pgconsul_pgconsul_net"]" for key "/pgconsul/postgresql/quorum"
+        Then <lock_type> "<lock_host>" has value "['pgconsul_postgresql2_1.pgconsul_pgconsul_net']" for key "/pgconsul/postgresql/quorum"
         When we wait "10.0" seconds
         When we <destroy> container "postgresql1"
         Then <lock_type> "<lock_host>" has holder "pgconsul_postgresql2_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"

--- a/tests/features/pgconsul_util.feature
+++ b/tests/features/pgconsul_util.feature
@@ -497,7 +497,7 @@ Feature: Check pgconsul-util features
         scheduled
         """
         Then <lock_type> "<lock_host>" has value "scheduled" for key "/pgconsul/postgresql/switchover/state"
-        And <lock_type> "<lock_host>" has value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net", "timeline": 1, "destination": null}" for key "/pgconsul/postgresql/switchover/master"
+        And <lock_type> "<lock_host>" has value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': null}" for key "/pgconsul/postgresql/switchover/master"
         When we run following command on host "postgresql1"
         """
         pgconsul-util switchover --reset
@@ -519,7 +519,7 @@ Feature: Check pgconsul-util features
         scheduled
         """
         Then <lock_type> "<lock_host>" has value "scheduled" for key "/pgconsul/postgresql/switchover/state"
-        And <lock_type> "<lock_host>" has value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net", "timeline": 1, "destination": null}" for key "/pgconsul/postgresql/switchover/master"
+        And <lock_type> "<lock_host>" has value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': null}" for key "/pgconsul/postgresql/switchover/master"
         When we release lock "/pgconsul/postgresql/alive/pgconsul_postgresql1_1.pgconsul_pgconsul_net" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/alive/pgconsul_postgresql2_1.pgconsul_pgconsul_net" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/alive/pgconsul_postgresql3_1.pgconsul_pgconsul_net" in <lock_type> "<lock_host>"

--- a/tests/features/primary_switch.feature
+++ b/tests/features/primary_switch.feature
@@ -47,7 +47,7 @@ Feature: Check primary switch logic
         When we gracefully stop "pgconsul" in container "postgresql2"
         And we kill "postgres" in container "postgresql2" with signal "9"
         And we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql3" became a primary

--- a/tests/features/start.feature
+++ b/tests/features/start.feature
@@ -51,7 +51,7 @@ Feature: Check startup logic
             state: streaming
         """
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql3" became a primary

--- a/tests/features/switchover.feature
+++ b/tests/features/switchover.feature
@@ -49,7 +49,7 @@ Feature: Check switchover
         When we remember postgresql start time in container "postgresql3"
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql3" became a primary
@@ -60,7 +60,7 @@ Feature: Check switchover
         And postgresql in container "postgresql1" was restarted
         Then container "postgresql1" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql3_1.pgconsul_pgconsul_net","timeline": 2}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql3_1.pgconsul_pgconsul_net','timeline': 2}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql1" became a primary
@@ -70,7 +70,7 @@ Feature: Check switchover
         And postgresql in container "postgresql2" was not rewinded
         When we stop container "postgresql2"
         And we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 3}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 3}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         And we wait "30.0" seconds
@@ -134,7 +134,7 @@ Feature: Check switchover
         """
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net","timeline": 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net','timeline': 1}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         When we wait "30.0" seconds
@@ -192,7 +192,7 @@ Feature: Check switchover
 
         """
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": null,"timeline": null}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': null,'timeline': null}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then <lock_type> "zookeeper1" has value "None" for key "/pgconsul/postgresql/switchover/master"

--- a/tests/features/targeted_switchover.feature
+++ b/tests/features/targeted_switchover.feature
@@ -45,7 +45,7 @@ Feature: Targeted switchover
         """
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net", 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql2" became a primary

--- a/tests/features/targeted_switchover.feature
+++ b/tests/features/targeted_switchover.feature
@@ -45,7 +45,7 @@ Feature: Targeted switchover
         """
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net", "timeline": 1, "destination": "pgconsul_postgresql2_1.pgconsul_pgconsul_net"}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net", 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql2" became a primary
@@ -107,7 +107,7 @@ Feature: Targeted switchover
         """
         Then container "postgresql3" is in <replication_type> group
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net", "timeline": 1, "destination": "pgconsul_postgresql2_1.pgconsul_pgconsul_net"}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         And we disconnect from network container "postgresql2"
@@ -124,7 +124,7 @@ Feature: Targeted switchover
         """
         And container "postgresql2" is a replica of container "postgresql1"
         When we lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
-        And we set value "{"hostname": "pgconsul_postgresql1_1.pgconsul_pgconsul_net", "timeline": 1, "destination": "pgconsul_postgresql2_1.pgconsul_pgconsul_net"}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in <lock_type> "<lock_host>"
         And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in <lock_type> "<lock_host>"
         And we release lock "/pgconsul/postgresql/switchover/lock" in <lock_type> "<lock_host>"
         Then container "postgresql2" became a primary

--- a/tests/steps/cluster.py
+++ b/tests/steps/cluster.py
@@ -723,7 +723,7 @@ def promote(context, name):
     helpers.promote_host(container)
 
 
-@when('we make switchover task with params "(?P<params>[a-zA-Z0-9_-]+)" in container "(?P<name>[a-zA-Z0-9_-]+)"')
+@when('we make switchover task with params "(?P<params>[ .a-zA-Z0-9_-]+)" in container "(?P<name>[a-zA-Z0-9_-]+)"')
 def set_switchover_task(context, params, name):
     container = context.containers[name]
     if params == "None":

--- a/tests/steps/zk.py
+++ b/tests/steps/zk.py
@@ -14,7 +14,7 @@ from behave import then, when, use_step_matcher
 use_step_matcher('re')
 
 @then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has holder "(?P<holders>[.a-zA-Z0-9_-]+)" for lock "(?P<key>[./a-zA-Z0-9_-]+)"')
-@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has one of holders "(?P<holders>[.a-zA-Z0-9_-]+)" for lock "(?P<key>[./a-zA-Z0-9_-]+)"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has one of holders "(?P<holders>[,.a-zA-Z0-9_-]+)" for lock "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_check_holders(context, name, holders, key):
     try:

--- a/tests/steps/zk.py
+++ b/tests/steps/zk.py
@@ -9,11 +9,12 @@ import kazoo.exceptions
 from kazoo.handlers.threading import KazooTimeoutError
 import steps.helpers as helpers
 import yaml
-from behave import then, when
+from behave import then, when, use_step_matcher
 
+use_step_matcher('re')
 
-@then('zookeeper "{name}" has holder "{holders}" for lock "{key}"')
-@then('zookeeper "{name}" has one of holders "{holders}" for lock "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has holder "(?P<holders>[.a-zA-Z0-9_-]+)" for lock "(?P<key>[./a-zA-Z0-9_-]+)"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has one of holders "(?P<holders>[.a-zA-Z0-9_-]+)" for lock "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_check_holders(context, name, holders, key):
     try:
@@ -37,24 +38,26 @@ def step_zk_check_holders(context, name, holders, key):
     )
 
 
-@when('we lock "{key}" in zookeeper "{name}"')
-@when('we lock "{key}" in zookeeper "{name}" with value "{value}"')
+@when('we lock "(?P<key>[./a-zA-Z0-9_-]+)" in zookeeper "(?P<name>[a-zA-Z0-9_-]+)"')
+@when('we lock "(?P<key>[./a-zA-Z0-9_-]+)" in zookeeper "(?P<name>[a-zA-Z0-9_-]+)" with value "(?P<value>[ \[\]{},.:\'a-zA-Z0-9_-]+)"')
 def step_zk_lock(context, key, name, value=None):
     if not context.zk:
         context.zk = helpers.get_zk(context, name)
         context.zk.start()
+    if value and "'" in value:
+        value = value.replace("'", '"')
     lock = context.zk.Lock(key, value)
     lock.acquire()
     context.zk_locks[key] = lock
 
 
-@when('we release lock "{key}" in zookeeper "{name}"')
+@when('we release lock "(?P<key>[./a-zA-Z0-9_-]+)" in zookeeper "(?P<name>[a-zA-Z0-9_-]+)"')
 def step_zk_release_lock(context, key, name):
     if key in context.zk_locks:
         context.zk_locks[key].release()
 
 
-@then('zookeeper "{name}" has no value for key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has no value for key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_no_value(context, name, key):
     zk_value = helpers.get_zk_value(context, name, key)
@@ -63,7 +66,7 @@ def step_zk_no_value(context, name, key):
     )
 
 
-@then('zookeeper "{name}" node is alive')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" node is alive')
 def step_zk_is_alive(context, name):
     key = '/test_is_{0}_alive'.format(name)
     try:
@@ -92,16 +95,18 @@ def try_to_repair_zk_host(context, name):
     container.exec_run("/usr/local/bin/supervisorctl restart zookeeper")
 
 
-@then('zookeeper "{name}" has value "{value}" for key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has value "(?P<value>[ \[\]{},.:\'a-zA-Z0-9_-]+)" for key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_value(context, name, value, key):
+    if value and "'" in value:
+        value = value.replace("'", '"')
     zk_value = helpers.get_zk_value(context, name, key)
     assert str(zk_value) == str(value), '{time}: expected value "{exp}", got "{val}"'.format(
         exp=value, val=zk_value, time=datetime.now().strftime("%H:%M:%S")
     )
 
 
-@then('zookeeper "{name}" has key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_key(context, name, key):
     assert helpers.zk_has_key(context, name, key), '{time}: key "{key}" is missing'.format(
@@ -109,7 +114,7 @@ def step_zk_key(context, name, key):
     )
 
 
-@then('zookeeper "{name}" doesn\'t have key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" doesn\'t have key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_key(context, name, key):
     assert not helpers.zk_has_key(context, name, key), '{time}: key "{key}" is present'.format(
@@ -117,7 +122,7 @@ def step_zk_key(context, name, key):
     )
 
 
-@then('zookeeper "{name}" has "{n}" values for key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has "(?P<n>[0-9]+)" values for key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_key_has_n_values(context, name, n, key):
     n = int(n)
@@ -129,7 +134,7 @@ def step_zk_key_has_n_values(context, name, n, key):
     )
 
 
-@then('zookeeper "{name}" has following values for key "{key}"')
+@then('zookeeper "(?P<name>[a-zA-Z0-9_-]+)" has following values for key "(?P<key>[./a-zA-Z0-9_-]+)"')
 @helpers.retry_on_assert
 def step_zk_key_values(context, name, key):
     exp_values = sorted(yaml.safe_load(context.text) or [], key=operator.itemgetter('client_hostname'))
@@ -173,7 +178,7 @@ def step_zk_set_value_with_retries(context, value, key, name):
     return step_zk_set_value(context, value, key, name)
 
 
-@when('we set value "{value}" for key "{key}" in zookeeper "{name}"')
+@when('we set value "(?P<value>[ \[\]{},.:\'a-zA-Z0-9_-]+)" for key "(?P<key>[./a-zA-Z0-9_-]+)" in zookeeper "(?P<name>[a-zA-Z0-9_-]+)"')
 def step_zk_set_value(context, value, key, name):
     try:
         zk = helpers.get_zk(context, name)
@@ -181,6 +186,8 @@ def step_zk_set_value(context, value, key, name):
         zk.ensure_path(key)
         # There is race condition, node can be deleted after ensure_path and
         # before set called. We need to catch exception and create it again.
+        if value and "'" in value:
+            value = value.replace("'", '"')
         try:
             zk.set(key, value.encode())
         except kazoo.exceptions.NoNodeError:
@@ -190,7 +197,7 @@ def step_zk_set_value(context, value, key, name):
         zk.close()
 
 
-@when('we remove key "{key}" in zookeeper "{name}"')
+@when('we remove key "(?P<key>[./a-zA-Z0-9_-]+)" in zookeeper "(?P<name>[a-zA-Z0-9_-]+)"')
 def step_zk_remove_key(context, key, name):
     try:
         zk = helpers.get_zk(context, name)


### PR DESCRIPTION
The default step_matcher has a problem: it accepts any type of quote in a variable. So, if we have a step with a pattern
foo "{a}"
and step like
foo "123"
Then, this step will be correct. But it makes no sense.
foo "123" bar "456"
(in this case a = '123" bar "456')

Thus, it is better to use regexp
