### PR TITLE
Fix infinite election

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1348,7 +1348,7 @@ class pgconsul(object):
             allow_data_loss,
             priority,
             self.db.get_wal_receive_lsn(),
-            len(helpers.make_current_replics_quorum(replica_infos, self.zk.get_alive_hosts(election_timeout / 2))),
+            len(helpers.make_current_replics_quorum(replica_infos, self.zk.get_alive_hosts(all_hosts_timeout=election_timeout / 3))),
         )
         try:
             return election.make_election()

--- a/src/zk.py
+++ b/src/zk.py
@@ -565,9 +565,11 @@ class Zookeeper(object):
             return []
         return [host for host in all_hosts if self._is_host_in_sync_quorum(host)]
 
-    def get_alive_hosts(self, timeout=1, catch_except=True):
+    def get_alive_hosts(self, timeout=1, catch_except=True, all_hosts_timeout=None):
         ha_hosts = self.get_ha_hosts()
         if ha_hosts is None:
             return []
+        if all_hosts_timeout:
+            timeout = max(timeout, all_hosts_timeout // len(ha_hosts))
         alive_hosts = [host for host in ha_hosts if self.is_host_alive(host, timeout, catch_except)]
         return alive_hosts

--- a/src/zk.py
+++ b/src/zk.py
@@ -570,6 +570,13 @@ class Zookeeper(object):
         if ha_hosts is None:
             return []
         if all_hosts_timeout:
-            timeout = max(timeout, all_hosts_timeout // len(ha_hosts))
+            minimal_total_timeout = timeout * len(ha_hosts)
+            if minimal_total_timeout > all_hosts_timeout:
+                logging.warning("The total timeout for checking the aliveness of all hosts (%s s) "
+                                "is greater than the all_hosts_timeout (%s s). "
+                                "Consider increasing the election timeout.",
+                                minimal_total_timeout, all_hosts_timeout)
+            else:
+                timeout = all_hosts_timeout / len(ha_hosts)
         alive_hosts = [host for host in ha_hosts if self.is_host_alive(host, timeout, catch_except)]
         return alive_hosts

--- a/src/zk.py
+++ b/src/zk.py
@@ -572,8 +572,9 @@ class Zookeeper(object):
         if all_hosts_timeout:
             minimal_total_timeout = timeout * len(ha_hosts)
             if minimal_total_timeout > all_hosts_timeout:
-                logging.warning("The total timeout for checking the aliveness of all hosts (%s s) "
-                                "is greater than the all_hosts_timeout (%s s). "
+                logging.warning("Expected timeout for checking host aliveness will be ignored.")
+                logging.debug("The minimal total timeout for checking the aliveness of all hosts (%s s) "
+                                "is greater than the expected one - all_hosts_timeout (%s s)."
                                 "Consider increasing the election timeout.",
                                 minimal_total_timeout, all_hosts_timeout)
             else:


### PR DESCRIPTION
When old master is gone, election can look like this:
Hosts in group A are waiting for the get_alive_hosts call at moment X in the _can_do_failover function. Each pgconsul inside of get_alive_hosts waits for each host's health to timeout = election_timeout / 2.
The hosts in group B start the election at moment X and wait for all active hosts to vote. The timeout is set to election_timeout / 2.

Hosts in group A at time X+election_ timeout/2 will mark the old master as dead and start an election (thus, A will become B). 
Hosts in group B, at moment X + election_timeout/2, will mark the election as failed due to hosts from group A. Then, a new iteration will start (thus, B becomes A).

So, we need to decrease timeout in get_alive_hosts. 
Also, we need to make that timeout works for all hosts in total, not for each of it.