### PR TITLE
More debug messages for failover

### DIFF
--- a/src/zk.py
+++ b/src/zk.py
@@ -263,7 +263,7 @@ class Zookeeper(object):
                 logging.error(line.rstrip())
             return False
 
-    def get(self, key, preproc=None):
+    def get(self, key, preproc=None, debug=False):
         """
         Get key value from zk
         """
@@ -271,6 +271,8 @@ class Zookeeper(object):
         try:
             res = self._get(path)
         except NoNodeError:
+            if debug:
+                logging.debug(f"NoNodeError when trying to get {key}")
             return None
         except (KazooException, KazooTimeoutError) as exception:
             raise ZookeeperException(exception)
@@ -279,6 +281,8 @@ class Zookeeper(object):
             try:
                 return preproc(value)
             except ValueError:
+                if debug:
+                    logging.debug(f"Failed to preproc value {value} (key {key})")
                 return None
         else:
             return value


### PR DESCRIPTION
I caught a failed switchover test. 
Check successful switchover with a dead primary and autofailover = and, quorum_commit = no. 
Here is the election log
Host2:
```
2024-08-29 05:57:58,752 DEBUG:	No lock instance for enter_election. Creating one.
2024-08-29 05:57:58,760 INFO:	Changing election status to: cleanup
2024-08-29 05:57:58,765 DEBUG:	Manage election
2024-08-29 05:57:58,767 DEBUG:	HA hosts are: ['pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'pgconsul_postgresql2_1.pgconsul_pgconsul_net', 'pgconsul_postgresql3_1.pgconsul_pgconsul_net']
2024-08-29 05:57:58,768 INFO:	Changing election status to: registration
2024-08-29 05:58:08,785 INFO:	Changing election status to: selection
2024-08-29 05:58:08,789 DEBUG:	HA hosts are: ['pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'pgconsul_postgresql2_1.pgconsul_pgconsul_net', 'pgconsul_postgresql3_1.pgconsul_pgconsul_net']
2024-08-29 05:58:08,790 ERROR:	Failed to get 'pgconsul_postgresql2_1.pgconsul_pgconsul_net' lsn for elections.
2024-08-29 05:58:08,790 ERROR:	Failed to get 'pgconsul_postgresql3_1.pgconsul_pgconsul_net' lsn for elections.
2024-08-29 05:58:08,791 INFO:	Collected votes are: {}
2024-08-29 05:58:08,791 ERROR:	Not enough votes for quorum.
```

Host3:
```
2024-08-29 05:57:58,810 DEBUG:	No lock instance for enter_election. Creating one.
2024-08-29 05:57:58,819 DEBUG:	Participate in election
2024-08-29 05:57:58,828 INFO:	Waiting 1 for election status done
2024-08-29 05:57:59,830 INFO:	Waiting 1.1661394208107576 for election status done
```

Definitely, it's a bug. I think the lsn is none, but I'm not sure. If we add more debug messages, we can find the problem when the test fails again.