### PR TITLE
MDB-30823: use replication lag in seconds instead of bytes, allow lag…

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -79,6 +79,7 @@ def read_config(filename=None, options=None):
             'verify_certs': 'no',
             'drop_slot_countdown': 10,
             'replication_slots_polling': None,
+            'max_allowed_switchover_lag_ms': 60000,
         },
         'primary': {
             'change_replication_type': 'yes',


### PR DESCRIPTION
in scheduled switchover, replication lag is allowed, because primary will be stopped before replica has promote. recognize, agree?