### PR TITLE
Close replica on partitioning to prevent its returning online but lagging

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -99,6 +99,7 @@ def read_config(filename=None, options=None):
             'recovery_timeout': 60,
             'can_delayed': 'no',
             'primary_switch_restart': 'yes',
+            'close_detached_after': 300,
         },
         'commands': {
             'promote': '/usr/lib/postgresql/10/bin/pg_ctl promote -D %p',

--- a/src/pg.py
+++ b/src/pg.py
@@ -359,6 +359,7 @@ class Postgres(object):
         Get wal_receiver info from pg_stat_wal_receiver
         """
         query = """SELECT pid, status, slot_name,
+                   COALESCE(1000*EXTRACT(epoch FROM last_msg_receipt_time), 0)::bigint AS last_msg_receipt_time_msec,
                    conninfo FROM pg_stat_wal_receiver"""
         return self._get(query)
 

--- a/tests/features/coordinator_fail.feature
+++ b/tests/features/coordinator_fail.feature
@@ -18,6 +18,7 @@ Feature: Check availability on coordinator failure
                     primary_switch_checks: 1
                     min_failover_timeout: 1
                     primary_unavailability_timeout: 2
+                    close_detached_after: 30
                 commands:
                     generate_recovery_conf: /usr/local/bin/gen_rec_conf_<with_slots>_slot.sh %m %p
         """
@@ -50,7 +51,7 @@ Feature: Check availability on coordinator failure
         When we disconnect from network container "zookeeper1"
         And we disconnect from network container "zookeeper2"
         And we disconnect from network container "zookeeper3"
-        And we wait "10.0" seconds
+        And we wait "35.0" seconds
         Then pgbouncer is running in container "postgresql1"
         And pgbouncer is running in container "postgresql2"
         And pgbouncer is running in container "postgresql3"

--- a/tests/features/kill_replica.feature
+++ b/tests/features/kill_replica.feature
@@ -285,3 +285,62 @@ Feature: Destroy synchronous replica in various scenarios
     Examples: <lock_type>
         | lock_type | lock_host  |
         | zookeeper | zookeeper1 |
+
+    @detached_replica
+    Scenario Outline: Disconnecting replica pgbouncer behaviour
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: '<use_slots>'
+                    quorum_commit: '<quorum_commit>'
+                primary:
+                    change_replication_type: 'yes'
+                    primary_switch_checks: 1
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_unavailability_timeout: 1
+                    primary_switch_checks: 1
+                    min_failover_timeout: 1
+                    primary_unavailability_timeout: 2
+                    close_detached_after: 30
+                commands:
+                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_<with_slots>_slot.sh %m %p
+        """
+        Given a following cluster with "<lock_type>" <with_slots> replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+        """
+        Then <lock_type> "<lock_host>" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        Then container "postgresql2" is in <replication_type> group
+        Then <lock_type> "<lock_host>" has following values for key "/pgconsul/postgresql/replics_info"
+        """
+          - client_hostname: pgconsul_postgresql2_1.pgconsul_pgconsul_net
+            state: streaming
+        """
+        When we disconnect from network container "postgresql2"
+        And we wait "5.0" seconds
+        Then pgbouncer is running in container "postgresql2"
+        When we wait "30.0" seconds
+        Then pgbouncer is not running in container "postgresql2"
+        When we connect to network container "postgresql2"
+        Then container "postgresql1" is primary
+        Then container "postgresql2" is a replica of container "postgresql1"
+        Then container "postgresql2" is in <replication_type> group
+        Then pgbouncer is running in container "postgresql2"
+        Then <lock_type> "<lock_host>" has following values for key "/pgconsul/postgresql/replics_info"
+        """
+          - client_hostname: pgconsul_postgresql2_1.pgconsul_pgconsul_net
+            state: streaming
+        """
+
+    Examples: <lock_type>, <with_slots> replication slots, <destroy>/<repair>
+        | lock_type | lock_host  | with_slots | use_slots | quorum_commit | replication_type |
+        | zookeeper | zookeeper1 |  without   |    no     |      yes      |      quorum      |
+        | zookeeper | zookeeper1 |   with     |    yes    |      yes      |      quorum      |
+        | zookeeper | zookeeper1 |  without   |    no     |      no       |       sync       |
+        | zookeeper | zookeeper1 |   with     |    yes    |      no       |       sync       |


### PR DESCRIPTION
- Remember time of each successful replica report to ZK.
- If ZK is unavailable, check if walreceiver is streaming.
- If both ZK and walreceiver checks fail, close replica.
- Log everything with values that triggered this logic.
- Add tests for this logic.