### PR TITLE
better slots on dead iter

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -77,7 +77,7 @@ def read_config(filename=None, options=None):
             'certfile': None,
             'ca_cert': None,
             'verify_certs': 'no',
-            'drop_slot_countdown': 10,
+            'drop_slot_countdown': 300,
             'replication_slots_polling': None,
             'max_allowed_switchover_lag_ms': 60000,
         },

--- a/src/main.py
+++ b/src/main.py
@@ -877,6 +877,7 @@ class pgconsul(object):
         holder = self.zk.get_current_lock_holder()
         if holder and holder != helpers.get_hostname():
             if role == 'replica' and holder == last_primary:
+                self._acquire_replication_source_slot_lock(last_primary)
                 logging.info('Seems that primary has not changed but PostgreSQL is dead. Starting it.')
                 return self.db.start_postgresql()
 

--- a/tests/features/cascade.feature
+++ b/tests/features/cascade.feature
@@ -364,6 +364,7 @@ Feature: Check not HA hosts
                     priority: 0
                     use_replication_slots: 'yes'
                     quorum_commit: 'yes'
+                    drop_slot_countdown: 10
                 primary:
                     change_replication_type: 'yes'
                     primary_switch_checks: 1

--- a/tests/features/kill_primary.feature
+++ b/tests/features/kill_primary.feature
@@ -303,6 +303,7 @@ Feature: Destroy primary in various scenarios
                     priority: 0
                     use_replication_slots: 'yes'
                     quorum_commit: 'yes'
+                    drop_slot_countdown: 10
                 primary:
                     change_replication_type: 'yes'
                     primary_switch_checks: 1

--- a/tests/features/slot.feature
+++ b/tests/features/slot.feature
@@ -8,6 +8,7 @@ Feature: Replication slots
                 global:
                     priority: 0
                     use_replication_slots: 'yes'
+                    drop_slot_countdown: 10
                 primary:
                     change_replication_type: 'no'
                     primary_switch_checks: 1


### PR DESCRIPTION
Yet another case where replica is waiting for replication_slot, but replication slot lock is not acquired.
drop_slot_countdown increased because start_pg command possibly can last longer that 10 iterations (=10s)