### PR TITLE
Fix pgconsul in docker compose environment

### DIFF
--- a/docker/pgconsul/supervisor.conf
+++ b/docker/pgconsul/supervisor.conf
@@ -24,12 +24,12 @@ stderr_logfile=/proc/self/fd/2
 stderr_logfile_maxbytes=0
 
 [program:pgconsul]
-command=/usr/local/bin/pgconsul -f yes
+# Sudo is used instead of the user attribute to set the correct user environment variables (for example, HOME).
+command=sudo -H -u postgres /usr/local/bin/pgconsul -f yes
 process_name=%(program_name)s
 autostart=false
 autorestart=true
 stopsignal=TERM
-user=postgres
 priority=10
 stdout_logfile=/var/log/pgconsul.log
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Я пытаюсь поиграться с pgconsul через docker compose окружение.

В текущей версии после выполнянения внутри контейнера `pgconsul_postgresql1_1` команды `pgconsul-util switchover -y -b` весь кластер разваливается, так как реплики не могут авторизоваться в новом primary.

Причина оказалась в том, что на старте окружения (я запуска через модифицированный `make jepsen`) сначала запускается PostgreSQL, а потом же поднимается `pgconsul`. `pgconsul` запускается через `supervisord`, которые выставялет ему пользователя, но не меняет переменные окружения (https://supervisord.org/subprocess.html#subprocess-environment):

 > Unlike **cron**, **supervisord** does not attempt to divine and override “fundamental” environment variables like `USER`, `PATH`, `HOME`, and `LOGNAME` when it performs a setuid to the user defined within the `user=` program config option. 

В частности `pgconsul`, хоть и запущен от имени пользователя `postgres`, получает `HOME` указывающий на `/root`.

После изменения конфигурации реплики она перезапускается уже самим `pgconsul`-ом и получает унаследованные от него переменные окружения (в том числе и `HOME`). В результате при попытке достучаться до primary реплика начинает искать пароль в файле `/root/.pgpass`, к которому у неё банально нет доступа.

Собственно в этом PR принудительно выпставляются переменные окружения пользователя через `sudo -H`. Возможно есть более красивый способ, но мне он на ум не пришел.