### PR TITLE
MDB-35088: await before changing replication type to async

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -90,6 +90,7 @@ def read_config(filename=None, options=None):
             'weekend_change_hours': '0-0',
             'primary_switch_checks': 3,
             'sync_replication_in_maintenance': 'yes',
+            'before_async_unavailability_timeout': 15,
         },
         'replica': {
             'primary_unavailability_timeout': 5,

--- a/src/replication_manager.py
+++ b/src/replication_manager.py
@@ -4,8 +4,26 @@ import time
 
 from . import helpers
 
+class NeededReplicationTypeMixin:
+    def __init__(self):
+        self._async_waiting_timestamp = None
 
-class SingleSyncReplicationManager:
+
+    def _get_needed_replication_type(self, config, db, db_state, ha_replics):
+        replication_type = _get_needed_replication_type_without_await_before_async(config, db, db_state, ha_replics)
+        if replication_type == 'async':
+            now = time.time()
+            if self._async_waiting_timestamp is None:
+                self._async_waiting_timestamp = now
+            if now - self._async_waiting_timestamp < self._config.getfloat('primary', 'before_async_unavailability_timeout'):
+                return 'sync'
+            return 'async'
+        else:
+            self._async_waiting_timestamp = None
+            return replication_type
+
+
+class SingleSyncReplicationManager(NeededReplicationTypeMixin):
     def __init__(self, config, db, _zk):
         self._config = config
         self._db = db
@@ -65,7 +83,7 @@ class SingleSyncReplicationManager:
 
         current = self._db.get_replication_state()
         logging.info('Current replication type is %s.', current)
-        needed = _get_needed_replication_type(self._config, self._db, db_state, ha_replics)
+        needed = self._get_needed_replication_type(self._config, self._db, db_state, ha_replics)
         logging.info('Needed replication type is %s.', needed)
 
         if needed != current[0]:
@@ -196,7 +214,7 @@ class SingleSyncReplicationManager:
         return self._zk.write(self._zk.REPLICS_INFO_PATH, replics_info, preproc=json.dumps)
 
 
-class QuorumReplicationManager:
+class QuorumReplicationManager(NeededReplicationTypeMixin):
     def __init__(self, config, db, _zk):
         self._config = config
         self._db = db
@@ -256,7 +274,7 @@ class QuorumReplicationManager:
         """
         current = self._db.get_replication_state()
         logging.info('Current replication type is %s.', current)
-        needed = _get_needed_replication_type(self._config, self._db, db_state, ha_replics)
+        needed = self._get_needed_replication_type(self._config, self._db, db_state, ha_replics)
         logging.info('Needed replication type is %s.', needed)
 
         if needed != current[0]:
@@ -322,7 +340,7 @@ class QuorumReplicationManager:
         return sync_quorum.get(helpers.get_oldest_replica(quorum_info))
 
 
-def _get_needed_replication_type(config, db, db_state, ha_replics):
+def _get_needed_replication_type_without_await_before_async(config, db, db_state, ha_replics):
     """
     return replication type we should set at this moment
     """

--- a/tests/features/kill_replica.feature
+++ b/tests/features/kill_replica.feature
@@ -158,6 +158,7 @@ Feature: Destroy synchronous replica in various scenarios
                 primary:
                     change_replication_type: 'yes'
                     primary_switch_checks: 1
+                    before_async_unavailability_timeout: 10
                 replica:
                     allow_potential_data_loss: 'no'
                     primary_unavailability_timeout: 1
@@ -187,7 +188,10 @@ Feature: Destroy synchronous replica in various scenarios
             sync_state: <replication_type>
         """
         When we disconnect from network container "postgresql2"
-        And we wait "35.0" seconds
+        And we wait "5.0" seconds
+        Then container "postgresql1" replication state is "sync"
+        When we wait "35.0" seconds
+        Then container "postgresql1" replication state is "async"
         Then <lock_type> "<lock_host>" has following values for key "/pgconsul/postgresql/replics_info"
         """
         """


### PR DESCRIPTION
In some cases hosts uses two different network interfaces: for zk connection and for replication. If there is 2-hosts (A,B) cluster and master (A) became unavailable not instantly (firstly - broken replication, then - zk connection): A will switch replication type to async instantly and write to zk that B is no longer sync/quorum replica. So, when zk connection also became broken and host A became fully unavailable - there might be some transactions that was commited into A, but not replicated to B. From this moment this transactions may be lost forever (if we can't fetch data from A), and host B can not become master.

So, there is why i added timeout before switching to async. In the situation described above A will wait _before_async_unavailability_timeout_ and maybe it will be enough to A to became fully unavailable (or available, who knows)