### PR TITLE
refactor: extract dependency creation from pgconsul class, add show-rewind-command CLI

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -179,6 +179,19 @@ def config_back_compatibility(config):
         config.set('commands', 'pg_stop', pg_stop)
 
 
+def _run_pgconsul(config):
+    """
+    Create connections and start pgconsul main loop.
+    Must be called after daemonization to avoid file descriptor issues.
+    DaemonContext closes all file descriptors, so ZK/PG connections
+    must be established after that.
+    """
+    db = create_postgres(config)
+    zk = create_zookeeper(config)
+    replication_manager = create_replication_manager(config, db, zk)
+    pgconsul(config=config, db=db, zk=zk, replication_manager=replication_manager).start()
+
+
 def start(config):
     """
     Start daemon
@@ -195,17 +208,15 @@ def start(config):
         pidfile.acquire()
     except AlreadyLocked:
         try:
-            os.kill(pidfile.read_pid(), 0)
-            print('Already running!')
-            sys.exit(1)
+            pid = pidfile.read_pid()
+            if pid is not None:
+                os.kill(pid, 0)
+                print('Already running!')
+                sys.exit(1)
         except OSError:
             pass
 
     pidfile.break_lock()
-
-    db = create_postgres(config)
-    zk = create_zookeeper(config)
-    replication_manager = create_replication_manager(config, db, zk)
 
     if config.getboolean('global', 'foreground'):
         working_dir = config.get('global', 'working_dir')
@@ -218,12 +229,12 @@ def start(config):
             stderr=sys.stderr,
             pidfile=pidfile,
         ):
-            pgconsul(config=config, db=db, zk=zk, replication_manager=replication_manager).start()
+            _run_pgconsul(config)
     else:
         working_dir = config.get('global', 'working_dir')
         logfile = open(config.get('global', 'log_file'), 'a')
         with daemon.DaemonContext(working_directory=working_dir, stdout=logfile, stderr=logfile, pidfile=pidfile):
-            pgconsul(config=config, db=db, zk=zk, replication_manager=replication_manager).start()
+            _run_pgconsul(config)
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -621,6 +621,22 @@ class pgconsul(object):
         holder = zk_state['lock_holder']
         limit = self.config.getfloat('replica', 'recovery_timeout')
 
+        # Check for timeline divergence before attempting to resume streaming
+        db_timeline = db_state.get('timeline')
+        zk_timeline = zk_state.get(self.zk.TIMELINE_INFO_PATH)
+
+        if db_timeline is not None and zk_timeline is not None and db_timeline != zk_timeline:
+            wal_receiver_status = db_state.get('wal_receiver')
+            logging.warning(
+                'Timeline divergence detected: db_timeline=%s, zk_timeline=%s, wal_receiver=%s. '
+                'Need to run pg_rewind before streaming can be established.',
+                db_timeline,
+                zk_timeline,
+                'running' if wal_receiver_status else 'stopped',
+            )
+            # Timeline mismatch detected - need pg_rewind
+            return self._return_to_cluster(holder, 'replica', is_dead=False)
+
         logging.debug('ACTION. Replica is returning. So we resume WAL replay to {}'.format(holder))
         self.db.ensure_replaying_wal()
 

--- a/src/types.py
+++ b/src/types.py
@@ -1,3 +1,16 @@
+from dataclasses import dataclass
+
 PluginsConfig = dict[str, str]
 ReplicaInfo = dict[str, int | str]
 ReplicaInfos = list[ReplicaInfo]
+
+
+@dataclass
+class ClusterInfo:
+    version: int
+    cluster_name: str
+    port: str
+    state: str
+    owner: str
+    pgdata: str
+    log_file: str

--- a/src/zk.py
+++ b/src/zk.py
@@ -8,6 +8,7 @@ import logging
 import os
 import traceback
 import time
+from configparser import RawConfigParser
 from random import uniform
 
 from kazoo.client import KazooClient, KazooState
@@ -17,6 +18,7 @@ from kazoo.recipe.lock import Lock
 from kazoo.security import make_digest_acl
 
 from . import helpers
+from .plugin import PluginRunner, load_plugins
 
 
 def _get_host_path(path, hostname):
@@ -770,3 +772,8 @@ class Zookeeper(object):
                 timeout = all_hosts_timeout / len(ha_hosts)
         alive_hosts = [host for host in ha_hosts if self.is_host_alive(host, timeout, catch_except)]
         return alive_hosts
+
+
+def create_zookeeper(config: RawConfigParser) -> Zookeeper:
+    plugins = load_plugins(config.get('global', 'plugins_path'))
+    return Zookeeper(config=config, plugins=PluginRunner(plugins['Zookeeper']))

--- a/src/zk.py
+++ b/src/zk.py
@@ -8,6 +8,7 @@ import logging
 import os
 import traceback
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from configparser import RawConfigParser
 from random import uniform
 
@@ -207,6 +208,30 @@ class Zookeeper(object):
     def _wait(self, event):
         event.wait(self._timeout)
 
+    def _run_with_timeout(self, func, timeout=None):
+        """
+        Run a synchronous kazoo operation with a timeout.
+        Kazoo Lock methods (contenders, acquire, release) and delete
+        use synchronous ZK calls internally that can hang indefinitely
+        if the connection is lost/restored during the operation.
+        This wrapper ensures they complete within the given timeout.
+        """
+        if timeout is None:
+            timeout = self._timeout
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(func)
+            try:
+                return future.result(timeout=timeout)
+            except FuturesTimeoutError:
+                logging.error(
+                    "Synchronous ZK operation timed out after %ds: %s",
+                    timeout,
+                    getattr(func, '__name__', repr(func)),
+                )
+                raise KazooTimeoutError(
+                    "Synchronous ZK operation timed out after %ds" % timeout
+                )
+
     def _get(self, path):
         event = self._zk.get_async(path)
         self._wait(event)
@@ -249,7 +274,7 @@ class Zookeeper(object):
             logging.warning('Not able to acquire %s ' % name + 'lock without alive connection.')
             return False
         lock = self._get_lock(name, read_lock)
-        contenders = lock.contenders()
+        contenders = self._run_with_timeout(lock.contenders)
         if len(contenders) != 0:
             if not read_lock:
                 contenders = contenders[:1]
@@ -260,7 +285,10 @@ class Zookeeper(object):
                 logging.warning('%s lock is already taken by %s.', name[0].upper() + name[1:], contenders[0])
                 return False
         try:
-            acquired = lock.acquire(blocking=True, timeout=timeout)
+            acquired = self._run_with_timeout(
+                lambda: lock.acquire(blocking=True, timeout=timeout),
+                timeout=timeout + self._timeout,
+            )
             if not acquired:
                 logging.warning('Unable to acquire lock "%s", but not because of timeout...', name)
         except LockTimeout:
@@ -295,7 +323,7 @@ class Zookeeper(object):
         if name in self._locks:
             lock = self._locks[name] # type: Lock
             self._delete_lock(name)
-            return lock.release()
+            return self._run_with_timeout(lock.release)
 
     def is_alive(self):
         """
@@ -339,16 +367,25 @@ class Zookeeper(object):
         try:
             for lock in self._locks.items():
                 if lock[1]:
-                    lock[1].release()
+                    try:
+                        self._run_with_timeout(lock[1].release)
+                    except Exception:
+                        pass
         except (KazooException, KazooTimeoutError):
             pass
 
+        self._locks = {}
         try:
-            self._locks = {}
             self._zk.remove_listener(self._listener)
             self._zk.stop()
             self._zk.close()
+        except Exception:
+            logging.warning("Error while stopping old ZK client (will be replaced with a new one)")
+            for line in traceback.format_exc().split('\n'):
+                logging.debug(line.rstrip())
 
+        try:
+            self._session_expired = False
             connected = self._init_client() and self.is_alive()
         except Exception:
             for line in traceback.format_exc().split('\n'):
@@ -391,6 +428,8 @@ class Zookeeper(object):
             return False
 
         logging.info("Successfully connected to ZooKeeper: %s", self._zk_hosts)
+        self._session_expired = False
+        self._failed_inits_count = 0
         self._zk.add_listener(self._listener)
         self._init_lock(self.PRIMARY_LOCK_PATH)
         return True
@@ -465,6 +504,12 @@ class Zookeeper(object):
         try:
             self._wait(event)
             return event.get_nowait()
+        except (ConnectionClosedError, SessionExpiredError):
+            logging.error('ZK connection closed during ensure_path: %s', path)
+            for line in traceback.format_exc().split('\n'):
+                logging.error(line.rstrip())
+            self._session_expired = True
+            return None
         except (KazooException, KazooTimeoutError):
             logging.error('Failed to ensure path: %s', path)
             for line in traceback.format_exc().split('\n'):
@@ -591,7 +636,7 @@ class Zookeeper(object):
         """
         path = self._path_prefix + key
         try:
-            self._zk.delete(path, recursive=recursive)
+            self._run_with_timeout(lambda: self._zk.delete(path, recursive=recursive))
             return True
         except NoNodeError:
             logging.info('No node %s was found in ZK to delete it.' % key)
@@ -616,7 +661,8 @@ class Zookeeper(object):
         including the holder.
         """
         try:
-            contenders = self._get_lock(name, read_lock).contenders()
+            lock = self._get_lock(name, read_lock)
+            contenders = self._run_with_timeout(lock.contenders)
             if len(contenders) > 0:
                 return contenders
         except Exception as e:

--- a/src/zk.py
+++ b/src/zk.py
@@ -83,6 +83,7 @@ class Zookeeper(object):
     SSN_PATH = f'{MEMBERS_PATH}/%s/synchronous_standby_names'
     SSN_VALUE_PATH = f'{SSN_PATH}/value'
     SSN_DATE_PATH = f'{SSN_PATH}/last_update'
+    SYNC_OPERATION_TIMEOUT = 5
 
     def __init__(self, config, plugins, lock_contender_name=None):
         self._lock_contender_name = lock_contender_name
@@ -129,8 +130,11 @@ class Zookeeper(object):
 
 
     def __del__(self):
-        self._zk.remove_listener(self._listener)
-        self._zk.stop()
+        try:
+            self._zk.remove_listener(self._listener)
+            self._zk.stop()
+        except Exception:
+            pass
 
     def _create_kazoo_client(self):
         """
@@ -217,7 +221,7 @@ class Zookeeper(object):
         This wrapper ensures they complete within the given timeout.
         """
         if timeout is None:
-            timeout = self._timeout
+            timeout = self.SYNC_OPERATION_TIMEOUT
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(func)
             try:


### PR DESCRIPTION
- Extract create_postgres(), create_zookeeper(), create_replication_manager()
  and create_command_manager() factory functions into respective modules
- Inject Postgres, Zookeeper, ReplicationManager via pgconsul constructor
  instead of creating them internally
- Add ClusterInfo dataclass for typed pg_lsclusters output parsing
- Change CommandManager.list_clusters() to return list[ClusterInfo]
- Add 'show-rewind-command' CLI subcommand to pgconsul-util
- Add CommandManager.show_command() for displaying prepared commands