### PR TITLE
MDB-44139: flap resistance in get_ha_hosts function

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -85,6 +85,7 @@ def read_config(filename=None, options=None):
             'max_delay_on_zk_reinit': 60,
             'async_log_queue_size': 5000,
             'welcome_message': '',
+            'ha_hosts_removal_delay': 60,
         },
         'primary': {
             'change_replication_type': 'yes',

--- a/src/list_removal_strategy.py
+++ b/src/list_removal_strategy.py
@@ -18,13 +18,13 @@ class DelayedListRemovalStrategy:
     When delay is 0, elements are removed immediately.
     """
     
-    def __init__(self, my_hostname: str, delay: float):
+    def __init__(self, delay: float, skip_removal_delay_hosts: set[str]|None=None):
         """
         Args:
-            my_hostname: Current host's FQDN
             delay: Delay in seconds before removing a replica (0 for immediate removal)
+            skip_removal_delay_hosts - delay will be 0 anyway for this hosts
         """
-        self._my_hostname = my_hostname
+        self._skip_removal_delay_hosts = skip_removal_delay_hosts
         self._delay = delay
         self._removal_timestamps: dict[str, float] = {}
     
@@ -91,7 +91,7 @@ class DelayedListRemovalStrategy:
         for host in current_quorum:
             if host not in quorum_hosts:
                 # Skip removal delay logic for own host - it cannot disappear from its own perspective
-                if host == self._my_hostname:
+                if self._skip_removal_delay_hosts and host in self._skip_removal_delay_hosts:
                     continue
                     
                 self.on_host_disappeared(host)

--- a/src/main.py
+++ b/src/main.py
@@ -417,6 +417,7 @@ class pgconsul(object):
             logging.warning('Failed to aquire primary lock.')
             self.resolve_zk_primary_lock(my_hostname, close_master_without_lock=False)
             return None
+        self.zk.update_ha_hosts()
         self._store_replics_info(db_state, zk_state)
 
         self.zk.write(self.zk.TIMELINE_INFO_PATH, db_state['timeline'])
@@ -464,6 +465,8 @@ class pgconsul(object):
                 self.resolve_zk_primary_lock(my_hostname)
                 return None
             self.zk.write(self.zk.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
+
+            self.zk.update_ha_hosts()
 
             self._reset_simple_primary_switch_try()
 

--- a/src/replication_manager.py
+++ b/src/replication_manager.py
@@ -319,8 +319,8 @@ class QuorumReplicationManager(ReplicationManager):
         my_hostname = helpers.get_hostname()
         # Always use DelayedListRemovalStrategy, with delay=0 for immediate removal
         self._removal_strategy = DelayedListRemovalStrategy(
-            my_hostname,
-            self._config.quorum_removal_delay
+            self._config.quorum_removal_delay,
+            skip_removal_delay_hosts={my_hostname}
         )
         if self._config.quorum_removal_delay > 0:
             logging.info(f'Using DelayedListRemovalStrategy with delay {self._config.quorum_removal_delay}s')

--- a/src/zk.py
+++ b/src/zk.py
@@ -9,6 +9,7 @@ import os
 import traceback
 import time
 from random import uniform
+from .list_removal_strategy import DelayedListRemovalStrategy
 
 from kazoo.client import KazooClient, KazooState
 from kazoo.exceptions import LockTimeout, NoNodeError, KazooException, ConnectionClosedError, SessionExpiredError
@@ -81,6 +82,9 @@ class Zookeeper(object):
     SSN_VALUE_PATH = f'{SSN_PATH}/value'
     SSN_DATE_PATH = f'{SSN_PATH}/last_update'
 
+    HA_HOSTS = 'ha_hosts'
+
+
     def __init__(self, config, plugins, lock_contender_name=None):
         self._lock_contender_name = lock_contender_name
         self._plugins = plugins
@@ -91,6 +95,8 @@ class Zookeeper(object):
         self._zk_hosts = config.get('global', 'zk_hosts')
         self._release_lock_after_acquire_failed = config.getboolean('global', 'release_lock_after_acquire_failed')
         self._timeout = config.getfloat('global', 'iteration_timeout')
+        self._ha_hosts_removal_strategy = DelayedListRemovalStrategy(config.getint('global', 'ha_hosts_removal_delay'))
+        self._ha_hosts = None
         self._zk_connect_max_delay = config.getfloat('global', 'zk_connect_max_delay')
         self._zk_auth = config.getboolean('global', 'zk_auth')
         self._zk_ssl = config.getboolean('global', 'zk_ssl')
@@ -568,7 +574,7 @@ class Zookeeper(object):
             sdata = str(data)
         return path, sdata
 
-    def write(self, key, data, preproc=None, need_lock=True):
+    def write(self, key, data, preproc=None, need_lock=True, catch_except=False):
         """
         Write value to key in zk
         """
@@ -578,22 +584,24 @@ class Zookeeper(object):
         except SessionExpiredError as exception:
             logging.error('ZK session expired during write operation')
             self._session_expired = True
+            if catch_except:
+                logging.exception('Failed to write zk node')
+                return False
             raise ZookeeperException(exception)
         except (KazooException, KazooTimeoutError) as exception:
             logging.error('Failed to write zk node %s (data size: %d bytes): %s', path, len(sdata), sdata)
             for line in traceback.format_exc().split('\n'):
                 logging.error(line.rstrip())
+            if catch_except:
+                logging.exception('Failed to write zk node')
+                return False
             raise ZookeeperException(exception)
 
     def noexcept_write(self, key, data, preproc=None, need_lock=True):
         """
         Write value to key in zk without zk exceptions forwarding
         """
-        try:
-            return self.write(key, data, preproc=preproc, need_lock=need_lock)
-        except Exception:
-            logging.exception('Failed to write zk node')
-            return False
+        return self.write(key, data, preproc=preproc, need_lock=need_lock, catch_except=True)
 
     def delete(self, key, recursive=False):
         """
@@ -739,7 +747,16 @@ class Zookeeper(object):
             hostname = helpers.get_hostname()
         return self.ELECTION_VOTE_PATH % hostname
 
-    def get_ha_hosts(self, catch_except=True):
+    def update_ha_hosts(self):
+        catch_except = True
+        if self._ha_hosts is None:
+            catch_except = False
+        ha_hosts = self.calculate_ha_hosts(catch_except=catch_except)
+        self._ha_hosts = self._ha_hosts_removal_strategy.get_hosts_to_keep(self._ha_hosts or [], ha_hosts)
+        logging.debug(f"Write HA hosts to zk: {self._ha_hosts}")
+        self.write(self.HA_HOSTS, self._ha_hosts, preproc=json.dumps, catch_except=catch_except)
+
+    def calculate_ha_hosts(self, catch_except=True):
         all_hosts = self.get_children(self.MEMBERS_PATH, catch_except=catch_except)
         if all_hosts is None:
             logging.error('Failed to get HA host list from ZK')
@@ -749,8 +766,16 @@ class Zookeeper(object):
             path = f"{self.MEMBERS_PATH}/{host}/ha"
             if self.exists_path(path, catch_except=catch_except):
                 ha_hosts.append(host)
-        logging.debug(f"HA hosts are: {ha_hosts}")
+        logging.debug(f"(calculated by /ha nodes) HA hosts are: {ha_hosts}")
         return ha_hosts
+
+    def get_ha_hosts(self, catch_except=True):
+        ha_hosts = self.get(self.HA_HOSTS, preproc=json.loads)
+        if ha_hosts is not None:
+            logging.debug(f"(from zk:{self.HA_HOSTS}) HA hosts are: {ha_hosts}")
+            return ha_hosts
+        logging.warning(f"HA hosts not defined in zk, we should make some calculations here")
+        return self.calculate_ha_hosts(catch_except=catch_except)
 
     def is_host_alive(self, hostname, timeout=0.0, catch_except=True):
         alive_path = self.get_host_alive_lock_path(hostname)

--- a/tests/test_list_removal_strategy.py
+++ b/tests/test_list_removal_strategy.py
@@ -22,7 +22,7 @@ class TestDelayedListRemovalStrategy:
     def setup(self):
         """Setup method executed before each test"""
         self.delay = 10.0
-        self.strategy = DelayedListRemovalStrategy('test-host', self.delay)
+        self.strategy = DelayedListRemovalStrategy(self.delay, skip_removal_delay_hosts={'test-host'})
     
     def test_host_kept_within_delay(self):
         """Host remains in quorum if not enough time has passed"""
@@ -115,7 +115,7 @@ class TestDelayedListRemovalStrategy:
     def test_own_host_not_delayed(self):
         """Own host removal is not delayed"""
         my_hostname = 'host1'
-        strategy = DelayedListRemovalStrategy(my_hostname, self.delay)
+        strategy = DelayedListRemovalStrategy(self.delay, skip_removal_delay_hosts={my_hostname})
         
         current_quorum = ['host1', 'host2']
         quorum_hosts = ['host2']  # host1 disappeared


### PR DESCRIPTION
We are currently non-atomically reading the list of ha_hosts from zk. So, if we get a zk exception when reading any ha node, we will immediately remove that node from the ha_hosts list. This may lead to incorrect cluster configuration (for example, single node mode may be enabled for a cluster with more than 2 ha nodes).

Now we will remove a host from ha_hosts only if its ha_node has been unavailable for a long time (default is 60 s).