### PR TITLE
MDB-42341: handle exception in pg_wal_replay_resume + fix race condition in cascade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,10 @@ src/                    # Main source code (pgconsul package)
 ├── exceptions.py       # Custom exceptions
 ├── list_removal_strategy.py       # Quorum list removal strategy
 ├── ssn_manager.py      # SSN (Sync Standby Names) management
+├── slot_manager.py     # Replication slot lifecycle management
 ├── log_formatters.py   # Log formatting
 ├── async_logging.py    # Asynchronous logging
+├── zk_client.py        # Low-level KazooClient wrapper (ZK connection management)
 └── sdnotify.py         # systemd integration
 ```
 
@@ -143,6 +145,39 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 
 - All added comments must be brief and in English
 
+### Error Handling
+
+#### PostgreSQL Errors (`src/exceptions.py`)
+
+The codebase uses a typed exception hierarchy for PostgreSQL errors — never return `None` to signal
+a DB error:
+
+| Exception | When to raise |
+|-----------|---------------|
+| `PostgresException` | Base class; do not raise directly |
+| `PostgresConnectionError` | Connection unavailable or dropped (`psycopg2.OperationalError`) |
+| `PostgresQueryError` | Query executed but returned an unexpected/invalid result |
+
+**Key convention:** `pg.py` internal methods translate `psycopg2.OperationalError` into
+`PostgresConnectionError` and **let it propagate to the caller**. Callers in `main.py` /
+`replication_manager.py` decide: use `try/except PostgresConnectionError` only in critical
+scenarios (switchover, failover, reconnect) where restarting the iteration is not safe.
+In all other cases the exception propagates up to `run_iteration()`, which restarts the iteration.
+
+**PROHIBITED in `pg.py` methods:** catching `PostgresConnectionError` inside the method itself
+and returning a safe default (e.g. `return []`, `return ('async', None)`, `return None`).
+This pattern hides DB errors from the iteration loop and prevents proper restart.
+The **only** allowed exception: `reconnect()`, which must catch connection errors by definition.
+
+**`@helpers.return_none_on_error` is intentionally kept only on `zk.noexcept_get()`** — that is
+the only place where `None` as a return value is a valid "no data" signal. Do **not** apply this
+decorator to new `pg.py` methods; raise `PostgresConnectionError` instead.
+
+#### ZooKeeper Errors
+
+- `zk.get()` / `zk.write()` raise `ZookeeperException` — callers decide to propagate or handle.
+- `zk.noexcept_get()` swallows exceptions and returns `None` — valid "soft" API for optional reads.
+
 ### Working with ZooKeeper
 
 - All ZK paths are defined as constants in the `Zookeeper` class (`src/zk.py`)
@@ -167,6 +202,32 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 
 - If `pg_rewind` fails more than `max_rewind_retries` times, the file `.pgconsul_rewind_fail.flag` is created
 - When this flag exists, pgconsul refuses to start — manual intervention is required
+
+---
+
+## Architecture Decision Records (ADR)
+
+Architectural decisions are documented in `adr/` as Markdown files named `ADR-NNNN-<slug>.md`.
+
+### Existing ADRs
+
+| File | Title | Status |
+|------|-------|--------|
+| [`adr/ADR-0001-typed-postgres-exception-hierarchy.md`](adr/ADR-0001-typed-postgres-exception-hierarchy.md) | Typed Exception Hierarchy for the PostgreSQL Layer | Accepted |
+| [`adr/ADR-0002-exception-propagation-to-run-iteration.md`](adr/ADR-0002-exception-propagation-to-run-iteration.md) | Exception Propagation Strategy to `run_iteration()` | Accepted |
+
+### When to create a new ADR
+
+Create a new ADR when making a decision that:
+- Changes the error-handling contract of a module (e.g. exceptions vs. return values)
+- Introduces or removes a cross-cutting mechanism (decorator, base class, protocol)
+- Establishes a new convention that all contributors must follow
+- Has non-obvious trade-offs that future maintainers should understand
+
+### ADR structure
+
+Each ADR must contain the following sections:
+`# Context` → `# Decision` → `# Alternatives` → `# Consequences` → `# Links`
 
 ---
 
@@ -196,4 +257,5 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 - Core logic: [`src/replication_manager.py`](src/replication_manager.py)
 - Configuration: [`src/replication_manager_factory.py`](src/replication_manager_factory.py)
 - SSN management: [`src/ssn_manager.py`](src/ssn_manager.py)
-- Tests: `tests/unit/test_replication_manager_*.py`, `tests/unit/test_ssn_manager.py`
+- Replication slot lifecycle: [`src/slot_manager.py`](src/slot_manager.py)
+- Tests: `tests/unit/test_replication_manager_*.py`, `tests/unit/test_ssn_manager.py`, `tests/unit/test_slot_manager.py`

--- a/adr/ADR-0001-typed-postgres-exception-hierarchy.md
+++ b/adr/ADR-0001-typed-postgres-exception-hierarchy.md
@@ -1,0 +1,159 @@
+# ADR-0001: Typed Exception Hierarchy for the PostgreSQL Layer
+
+**Status:** Accepted  
+**Date:** 2026-07-22  
+**Deciders:** kopylov74, mialinx  
+**Ticket:** MDB-41953 (parent: MDB-46662)
+
+---
+
+## Context
+
+`src/pg.py` contains methods that query PostgreSQL via `psycopg2`. Historically, these methods
+were annotated with `@helpers.return_none_on_error` — a decorator that catches **any** exception
+and returns `None` instead of propagating it:
+
+```python
+def return_none_on_error(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            logging.exception('Unhandled exception in %s', func.__name__)
+            return None
+    return wrapper
+```
+
+This approach creates a critical ambiguity: the return value `None` carries two completely
+different meanings in the codebase:
+
+| Meaning | Example |
+|---------|---------|
+| "no data" (valid empty result) | `get_replication_slots()` returns `None` / `[]` when no slots exist |
+| "error" (connection lost, query failed) | `get_replication_slots()` returns `None` because `psycopg2.OperationalError` was swallowed |
+
+Callers in `main.py` either:
+- silently skip logic on `None` (treating both cases as "no data"), or
+- perform an explicit `res is None` guard, but cannot distinguish the cause.
+
+The codebase mixes two error-handling idioms — Python exceptions and Go-style
+`None`-as-error sentinel — producing the worst properties of both: exceptions are invisible
+to callers, and `None`-checks require the caller to "know" whether `None` means "empty" or "error".
+
+---
+
+## Decision
+
+Introduce a **typed exception hierarchy** for all PostgreSQL-related errors in `src/exceptions.py`
+and consistently raise these exceptions from `pg.py` methods instead of returning `None`.
+
+### Exception hierarchy (added to `src/exceptions.py`)
+
+```python
+class PostgresException(pgconsulException):
+    """Base class for all PostgreSQL errors. Do not raise directly."""
+
+class PostgresConnectionError(PostgresException):
+    """Connection to PostgreSQL is unavailable or dropped.
+    Wraps psycopg2.OperationalError."""
+
+class PostgresQueryError(PostgresException):
+    """Query executed but returned an unexpected or invalid result."""
+```
+
+### Mapping rules for `pg.py`
+
+| Situation | Before | After |
+|-----------|--------|-------|
+| `psycopg2.OperationalError` (connection lost) | `return None` | raise `PostgresConnectionError` |
+| Query returns logically invalid data | `return None` | raise `PostgresQueryError` |
+| Empty but valid result (e.g. no slots) | `return []` | `return []` (unchanged) |
+| Normal result | `return value` | `return value` (unchanged) |
+
+### Prohibition on catching `PostgresConnectionError` inside `pg.py`
+
+Methods in `pg.py` **must not** catch `PostgresConnectionError` internally and return a safe
+default. Doing so hides DB errors from the iteration loop and prevents proper iteration restart.
+The **only** allowed exception is `reconnect()`, which must handle connection errors by definition.
+
+### `@helpers.return_none_on_error` retention policy
+
+The decorator **must not** be applied to any new `pg.py` methods.
+It is intentionally retained only on `zk.noexcept_get()` — the one place where `None` is a
+valid "no data" signal (ZK optional reads are non-blocking by design).
+
+---
+
+## Alternatives
+
+### A1. Keep `@return_none_on_error` + add explicit `None` guards everywhere
+
+Callers in `main.py` check `if res is None: return` or `if res is None: raise ...`.
+
+**Against:**
+- Perpetuates the ambiguity between "empty result" and "error"
+- Not idiomatic Python — mixes two incompatible paradigms
+- Every new caller must remember to guard against `None`
+- Error context is logged at the decorator level; caller loses the traceback
+
+### A2. Introduce a sentinel object (e.g. `MISSING = object()`)
+
+Methods return `MISSING` on error and a real value otherwise.
+
+**Against:**
+- Adds a new abstraction that still requires caller-side checks
+- Does not carry error information (type, message, traceback)
+- Not standard Python practice; harder to integrate with `mypy`
+
+### A3. Return `Optional[T]` and document the convention clearly
+
+Keep `None` returns, but strictly document "None = error, [] = empty".
+
+**Against:**
+- Documentation drift is guaranteed over time
+- `mypy` cannot distinguish the two `None` meanings at the type level
+- Does not fix the root cause; formalises the ambiguity without resolving it
+
+---
+
+## Consequences
+
+### Positive
+- ✅ **Disambiguation:** connection errors are distinguishable from empty results at the type level
+- ✅ **Observability:** exceptions carry a full traceback; callers get complete context
+- ✅ **mypy compatibility:** `Optional[T]` return types can be narrowed where `None` was only returned on error
+- ✅ **Fail-fast:** uncaught `PostgresConnectionError` propagates to `run_iteration()` and triggers iteration restart — the correct behaviour
+- ✅ **Prevents a class of bugs** where empty-result logic was applied to error conditions
+
+### Negative
+- ❌ **Migration effort:** all call sites of `@return_none_on_error`-decorated methods must be audited and updated
+- ❌ **Risk during transition:** if a call site is not updated, an unhandled `PostgresConnectionError` may surface as an unexpected exception — however this is a **safer** failure mode than silently operating on stale data
+
+### Technical Debt Resolved
+- `@helpers.return_none_on_error` usage on `pg.py` methods
+- Mixed `None`/exception idiom across `pg.py` + `main.py`
+
+---
+
+## Revisit Criteria
+
+Reconsider if:
+1. A method genuinely needs to return `None` as a valid "no data" signal **and** can also fail — introduce a dedicated `Result` type or a domain-specific sentinel in that case.
+2. A future refactoring merges `pg.py` and `zk.py` error handling into a unified infrastructure layer — revisit the hierarchy to avoid duplication.
+
+---
+
+## Links
+
+- **Related ADR:**
+  - [ADR-0002](ADR-0002-exception-propagation-to-run-iteration.md) — Exception propagation strategy to `run_iteration()`
+
+- **Related Code:**
+  - [`src/exceptions.py`](../src/exceptions.py) — exception hierarchy
+  - [`src/helpers.py`](../src/helpers.py) — `return_none_on_error` decorator
+  - [`src/pg.py`](../src/pg.py) — PostgreSQL abstraction layer
+
+- **Related Tickets:**
+  - MDB-41953 — this ticket
+  - MDB-46662 — parent refactoring epic

--- a/adr/ADR-0002-exception-propagation-to-run-iteration.md
+++ b/adr/ADR-0002-exception-propagation-to-run-iteration.md
@@ -1,0 +1,160 @@
+# ADR-0002: Exception Propagation Strategy to `run_iteration()`
+
+**Status:** Accepted  
+**Date:** 2026-07-22  
+**Deciders:** kopylov74, mialinx  
+**Ticket:** MDB-41953 (parent: MDB-46662)
+
+---
+
+## Context
+
+`pgconsul` operates as an infinite loop: every second `run_iteration()` is called, which
+determines the node role and dispatches to `primary_iter()`, `replica_iter()`,
+`non_ha_replica_iter()`, or `dead_iter()`.
+
+```python
+while should_run():
+    run_iteration()   # restart on any unhandled exception
+    timer.sleep(...)
+```
+
+With the introduction of typed PostgreSQL exceptions (see [ADR-0001]) the question becomes:
+**who should catch `PostgresConnectionError` / `PostgresQueryError`, and where?**
+
+Two fundamentally different strategies exist:
+
+| Strategy | Description |
+|----------|-------------|
+| **"Python-way"** | Let exceptions propagate freely to `run_iteration()`; add selective `try/except` only in critical sections where restarting the iteration is unsafe |
+| **"Go-way"** | Handle exceptions at the call site; return `None` or a fallback value; guard every call with `if res is None` |
+
+The "Go-way" was the previous approach (via `@return_none_on_error`) and is being retired
+per ADR-0003. The new policy must be stated explicitly so that all contributors follow
+the same convention.
+
+---
+
+## Decision
+
+Adopt the **"Python-way" exception propagation** model:
+
+1. **Default: let exceptions propagate to `run_iteration()`.**  
+   Methods in `pg.py` raise `PostgresConnectionError` or `PostgresQueryError`.
+   Callers in `main.py` / `replication_manager.py` do **not** catch these exceptions unless
+   they are in a critical section (see below).
+   `run_iteration()` catches any unhandled exception, logs it, and starts the next iteration.
+
+2. **Exception: critical sections that cannot safely restart the iteration.**  
+   Some operations are stateful and cannot be interrupted mid-flight:
+   - **Switchover** (`utils.Switchover`) — the cluster is already transitioning; restarting
+     the iteration without completing or cleanly aborting the switchover would leave the
+     cluster in an inconsistent state.
+   - **Failover election** (`failover_election.py`) — the election protocol has timing
+     invariants; a silent restart could cause split-brain.
+   
+   In these sections, callers **must** explicitly `try/except PostgresConnectionError` (and/or
+   `PostgresQueryError`) and either raise a domain-specific exception
+   (`SwitchoverException`, `FailoverException`) or take a safe compensating action.
+
+3. **`reconnect()` is the only method in `pg.py` that may catch `PostgresConnectionError`.**  
+   This is structurally necessary: `reconnect()` is the recovery path for lost connections.
+
+### Decision rule (applied per call site)
+
+```
+Is the caller inside a critical section (switchover / failover election)?
+├── YES → add try/except PostgresConnectionError; raise domain exception or handle explicitly
+└── NO  → do not catch; let the exception propagate to run_iteration()
+```
+
+### What `run_iteration()` does on an unhandled exception
+
+```python
+def run_iteration(self):
+    try:
+        ...
+    except Exception:
+        logging.exception('Unhandled exception in run_iteration')
+        # iteration ends; the loop starts the next one after sleep
+```
+
+This guarantees that any DB error that escapes a non-critical caller is logged with a full
+traceback and the daemon continues on the next iteration — the safest possible default.
+
+---
+
+## Alternatives
+
+### A1. "Go-way": handle at every call site, return `None` on error
+
+Every `pg.py` caller checks `if res is None` and returns early.
+
+**Against:**
+- Perpetuates the root cause of MDB-41953 (see ADR-0001)
+- Callers must be aware of the `None`-means-error convention
+- Errors are silently swallowed; no traceback at the call site
+- Logic that depends on an empty result vs. an error behaves incorrectly
+
+### A2. Catch all exceptions in `primary_iter()` / `replica_iter()` top-level
+
+Add a single `try/except` at the top of each `*_iter()` method.
+
+**Against:**
+- Equivalent to the current behaviour (swallows exceptions one level higher)
+- Does not propagate context to `run_iteration()` for uniform logging
+- Still does not distinguish "connection error" from "logic error"
+
+### A3. Catch only `PostgresConnectionError` everywhere, re-raise others
+
+**Against:**
+- Creates a large number of identical boilerplate `try/except` blocks
+- Violates the single-responsibility principle: each method handles its own error
+  *and* the iteration-restart policy
+- The same goal is achieved more cleanly by propagating to `run_iteration()`
+
+---
+
+## Consequences
+
+### Positive
+- ✅ **Uniform error handling:** all DB errors are logged at a single point (`run_iteration()`) with a consistent format
+- ✅ **Less boilerplate:** callers do not need per-call `if res is None` guards
+- ✅ **mypy-friendly:** return types of `pg.py` methods no longer need `Optional[T]` where `None` signalled an error
+- ✅ **Explicit critical sections:** the need for `try/except` in switchover/failover code is documented and intentional, not accidental
+
+### Negative
+- ❌ **Transition risk:** existing callers that rely on `None`-as-error must be audited before removing `@return_none_on_error`; a missing audit causes an unhandled exception to surface in `run_iteration()` — a **visible** failure, but still a failure
+- ❌ **Learning curve:** contributors must understand which call sites are "critical" and require explicit error handling
+
+### Technical Debt Introduced
+- A catalogue of "critical sections" must be maintained (currently: switchover, failover election). New critical sections must be identified and documented when added.
+
+### Technical Debt Resolved
+- Implicit `None`-propagation through `@return_none_on_error` in non-critical paths
+
+---
+
+## Revisit Criteria
+
+Reconsider if:
+1. A new operation is introduced that is neither a full iteration nor a named critical section (e.g. a background thread) — define its error boundary explicitly.
+2. `run_iteration()` is split into smaller autonomous units — re-evaluate where the "restart" boundary sits.
+
+---
+
+## Links
+
+- **Related ADR:**
+  - [ADR-0001](ADR-0001-typed-postgres-exception-hierarchy.md) — Typed exception hierarchy for the PostgreSQL layer
+
+- **Related Code:**
+  - [`src/main.py`](../src/main.py) — `run_iteration()`, `primary_iter()`, `replica_iter()`
+  - [`src/utils.py`](../src/utils.py) — `Switchover`, `Failover` classes
+  - [`src/failover_election.py`](../src/failover_election.py) — failover election logic
+  - [`src/exceptions.py`](../src/exceptions.py) — `SwitchoverException`, `FailoverException`, `PostgresConnectionError`
+
+- **Related Tickets:**
+  - MDB-41953 — this ticket
+  - MDB-41954 — switchover protocol refactoring (tightly coupled)
+  - MDB-46662 — parent refactoring epic

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -34,3 +34,28 @@ class ResetException(pgconsulException):
     """
 
     pass
+
+
+class PostgresException(pgconsulException):
+    """
+    Base exception for all PostgreSQL-related errors.
+    """
+
+    pass
+
+
+class PostgresConnectionError(PostgresException):
+    """
+    Raised when the connection to PostgreSQL is unavailable or interrupted.
+    Distinguishes a missing DB connection from an empty query result.
+    """
+
+    pass
+
+
+class PostgresQueryError(PostgresException):
+    """
+    Raised when a query executes but returns an unexpected or invalid result.
+    """
+
+    pass

--- a/src/failover_election.py
+++ b/src/failover_election.py
@@ -210,15 +210,26 @@ class FailoverElection(object):
         #
         # The order of actions inside this function is very important and was validated to avoid race conditions.
         #
+
+        def _sleep_if_loser(is_winner: bool):
+            # Sleep only if a winner was actually elected (STATUS_DONE) and it is not us.
+            # A failed election (e.g. no quorum, status stays SELECTION) must not sleep,
+            # otherwise the manager becomes unavailable for the next voting round and the
+            # election never converges.
+            if is_winner or election_loser_timeout <= 0:
+                return
+            if self._zk.get_election_status() != STATUS_DONE:
+                return
+            logging.debug('Sleep for test purposes for an election loser %s' % election_loser_timeout)
+            time.sleep(election_loser_timeout)
+
         if not self._zk.try_acquire_lock(self._zk.ELECTION_ENTER_LOCK_PATH, allow_queue=True, timeout=self._timeout):
             return False
         if self._zk.get_current_lock_holder(self._zk.ELECTION_MANAGER_LOCK_PATH):
             self._zk.release_lock(self._zk.ELECTION_ENTER_LOCK_PATH)
-            result = self._participate_in_election()
-            if not result and election_loser_timeout > 0:
-                logging.debug('Sleep for test purposes for an election loser %s' % election_loser_timeout)
-                time.sleep(election_loser_timeout)
-            return result
+            is_winner = self._participate_in_election()
+            _sleep_if_loser(is_winner)
+            return is_winner
 
         if self._zk.get_current_lock_holder(self._zk.PRIMARY_LOCK_PATH):
             return False
@@ -230,4 +241,5 @@ class FailoverElection(object):
             is_winner = self._manage_election()
         finally:
             self._zk.release_lock(self._zk.ELECTION_MANAGER_LOCK_PATH)
+        _sleep_if_loser(is_winner)
         return is_winner

--- a/src/main.py
+++ b/src/main.py
@@ -21,8 +21,10 @@ from .log_formatters import format_db_state_for_log, format_zk_state_for_log, lo
 from .command_manager import CommandManager, Commands
 from .failover_election import ElectionError, FailoverElection
 from .helpers import IterationTimer, get_hostname, register_sigterm_handler, should_run
+from .exceptions import PostgresConnectionError
 from .pg import Postgres, PostgresConfig
 from .replication_manager_factory import create_replication_manager
+from .slot_manager import create_replication_slot_manager
 from .types import ReplicaInfos
 from .zk import Zookeeper, ZookeeperException, create_zk
 
@@ -55,11 +57,11 @@ class pgconsul(object):
         self.checks = {'primary_switch': 0, 'rewind': 0}
         self._is_single_node = False
         self.notifier = sdnotify.Notifier()
-        self._slot_drop_countdown: dict[str, int] = {}
         self._master_lost_ts: float|None = None
         self._debug_counters: dict[str, int] = {}
         self.last_zk_host_stat_write: float = 0
         self._replication_manager = create_replication_manager(self.config, self.db, self.zk)
+        self._slot_manager = create_replication_slot_manager(self.config, self.db, self.zk)
 
     def _commands(self) -> Commands:
         if self.config.has_section('commands'):
@@ -463,7 +465,7 @@ class pgconsul(object):
             # release replication source locks
             self._acquire_replication_source_slot_lock(None)
 
-            self._handle_slots()
+            self._slot_manager.handle_slots()
 
             self._store_replics_info(db_state, zk_state)
 
@@ -777,7 +779,7 @@ class pgconsul(object):
                 if zk_state.get(self.zk.SWITCHOVER_STATE_PATH) is None:
                     self.db.ensure_restoring_wal()
             self._reset_simple_primary_switch_try()
-            self._handle_slots()
+            self._slot_manager.handle_slots()
         except Exception:
             logging.exception('Unexpected error during replica iteration')
             return None
@@ -822,7 +824,7 @@ class pgconsul(object):
             not self.zk.get_current_lock_holder() and \
             not self.config.getboolean('global', 'autofailover'):
             logging.warning('Nobody holds the leader lock, but autofailover is disabled, falling back to failover')
-            return self._accept_failover(zk_state=zk_state, switchover_in_progress=True)
+            return self._accept_failover(switchover_in_progress=True)
 
         if switchover_state not in ('initiated', 'candidate_found'):
             logging.warning('Switchover state is %s, will not proceed.', switchover_state)
@@ -845,7 +847,7 @@ class pgconsul(object):
             logging.info('Current host is the candidate, waiting for side replicas...')
 
             # create slots before promote in order to allow side replicas to turn
-            if not self._create_replication_slots(side_replicas):
+            if not self._slot_manager.create_slots_for_hosts(side_replicas):
                 return False
 
             # wait for all alive side replicas to start streaming from the candidate
@@ -947,7 +949,7 @@ class pgconsul(object):
                 logging.error('According to ZK primary has died. We should verify it and do failover if possible.')
                 if self._master_lost_ts is None and zk_state[self.zk.TIMELINE_INFO_PATH] is not None:
                     self._master_lost_ts = time.time()
-                return self._accept_failover(zk_state=zk_state)
+                return self._accept_failover()
             self._master_lost_ts = None
 
             if holder != db_state['primary_fqdn'] and holder != my_hostname:
@@ -973,7 +975,7 @@ class pgconsul(object):
             self._reset_simple_primary_switch_try()
 
             self._replication_manager.enter_sync_group(replica_infos=replics_info)
-            self._handle_slots()
+            self._slot_manager.handle_slots()
         except Exception:
             logging.exception('Unexpected error during sync replica iteration')
             return None
@@ -1286,57 +1288,6 @@ class pgconsul(object):
         self.db.checkpoint()
         return True
 
-    def _handle_slots(self):
-        if not self.config.getboolean('global', 'replication_slots_polling'):
-            return
-
-        my_hostname = helpers.get_hostname()
-        try:
-            slot_lock_holders = set(self.zk.get_lock_contenders(os.path.join(self.zk.HOST_REPLICATION_SOURCES, my_hostname), read_lock=True, catch_except=False))
-        except Exception as e:
-            logging.warning(
-                'Could not get slot lock holders. %s'
-                'Can not handle replication slots. We will skip it this time', e
-            )
-            return
-        all_hosts = self.zk.get_members()
-        if not all_hosts:
-            logging.warning(
-                'Could not get all hosts list from ZK.'
-                'Can not handle replication slots. We will skip it this time'
-            )
-            return
-        non_holders_hosts = []
-
-        for host in all_hosts:
-            if host in slot_lock_holders:
-                self._slot_drop_countdown[host] = self.config.getint('global', 'drop_slot_countdown')
-            else:
-                if host not in self._slot_drop_countdown:
-                    self._slot_drop_countdown[host] = self.config.getint('global', 'drop_slot_countdown')
-                self._slot_drop_countdown[host] -= 1
-                if self._slot_drop_countdown[host] < 0:
-                    non_holders_hosts.append(host)
-
-        # create slots
-        slot_names = [helpers.app_name_from_fqdn(fqdn) for fqdn in slot_lock_holders]
-        actual_replication_slots = self.db.get_replication_slots()
-        if actual_replication_slots is None:
-            logging.warning('Failed to get actual replication slots')
-            # However, we can continue here and try to create slots. None of slots will be dropped, but some might be created
-        else:
-            logging.debug('Actual replication slots: %s', actual_replication_slots)
-
-        if not self.db.create_replication_slots(slot_names, verbose=False):
-            logging.warning('Could not create replication slots. %s', slot_names)
-
-        # drop slots
-        if my_hostname in non_holders_hosts:
-            non_holders_hosts.remove(my_hostname)
-        slot_names_to_drop = [helpers.app_name_from_fqdn(fqdn) for fqdn in non_holders_hosts]
-        if not self.db.drop_replication_slots(slot_names_to_drop, verbose=False):
-            logging.warning('Could not drop replication slots. %s', slot_names_to_drop)
-
     def _get_db_state(self):
         state = self.db.get_database_cluster_state()
         if not state or state == '':
@@ -1462,13 +1413,16 @@ class pgconsul(object):
 
         self._stop_timing('downtime')
 
-        self._slot_drop_countdown = {}
+        self._slot_manager.reset_on_promote()
 
         if not self.zk.write_failover_state('checkpointing'):
             logging.warning('Could not write failover state to ZK.')
 
         logging.debug('Doing checkpoint after promoting.')
-        if not self.db.checkpoint(query=self.config.get('debug', 'promote_checkpoint_sql', fallback=None)):
+        # checkpoint after promote is cosmetic — promote already succeeded.
+        try:
+            self.db.checkpoint(query=self.config.get('debug', 'promote_checkpoint_sql', fallback=None))
+        except PostgresConnectionError:
             logging.warning('Could not checkpoint after failover.')
 
         my_tli = self.db.get_timeline()
@@ -1484,15 +1438,6 @@ class pgconsul(object):
 
         return True
 
-    def _create_replication_slots(self, hosts):
-        if self.config.getboolean('global', 'use_replication_slots'):
-            # Create replication slots, regardless of whether replicas hold DCS locks for replication slots.
-            hosts = [helpers.app_name_from_fqdn(fqdn) for fqdn in hosts]
-            if not self.db.create_replication_slots(hosts):
-                logging.error('Could not create replication slots. Releasing the lock in ZK.')
-                return False
-        return True
-
     def _promote_handle_slots(self):
         if not self.zk.write_failover_state('creating_slots'):
             logging.warning('Could not write failover state to ZK.')
@@ -1504,7 +1449,7 @@ class pgconsul(object):
                 'are unable to do it. Releasing the lock.'
             )
             return False
-        return self._create_replication_slots(hosts)
+        return self._slot_manager.create_slots_for_hosts(list(hosts))
 
     def _check_my_timeline_sync(self):
         my_tli = self.db.get_timeline()
@@ -1603,7 +1548,7 @@ class pgconsul(object):
             self._replication_manager,
             allow_data_loss,
             self.config.getint('global', 'priority'),
-            self.db.get_wal_receive_lsn() or '0',
+            self.db.get_wal_receive_lsn(),
             quorum_size,
         )
         try:
@@ -1641,30 +1586,39 @@ class pgconsul(object):
             info['priority'] = int(prio) if prio is not None else None
         return replica_infos
 
-    def _accept_failover(self, zk_state, switchover_in_progress=False):
+    def _accept_failover(self, switchover_in_progress=False):
         """
         Failover magic is here
+
+        Failover is a critical section (see ADR-0002): a DB connection loss
+        during the checks is recoverable (abort the failover, the iteration
+        restarts), while any other unexpected error propagates to
+        run_iteration() for uniform logging and restart.
         """
-        if not self._can_do_failover(switchover_in_progress):
+        try:
+            if not self._can_do_failover(switchover_in_progress):
+                return None
+
+            self._start_timing('downtime', ts=self._master_lost_ts)
+            self._start_timing('failover', ts=self._master_lost_ts)
+
+            #
+            # All checks are done. Acquiring the lock in ZK, promoting and
+            # writing last failover timestamp to ZK.
+            #
+            if not self.zk.try_acquire_lock():
+                logging.info('Could not acquire lock in ZK. Not doing anything.')
+                return None
+            self.db.pg_wal_replay_resume()
+
+            if not self._do_failover():
+                return False
+
+            self.zk.write_last_failover_time()
+            self._stop_timing('failover')
+        except PostgresConnectionError:
+            logging.warning('DB connection lost during failover checks. Aborting failover.')
             return None
-
-        self._start_timing('downtime', ts=self._master_lost_ts)
-        self._start_timing('failover', ts=self._master_lost_ts)
-
-        #
-        # All checks are done. Acquiring the lock in ZK, promoting and
-        # writing last failover timestamp to ZK.
-        #
-        if not self.zk.try_acquire_lock():
-            logging.info('Could not acquire lock in ZK. Not doing anything.')
-            return None
-        self.db.pg_wal_replay_resume()
-
-        if not self._do_failover():
-            return False
-
-        self.zk.write_last_failover_time()
-        self._stop_timing('failover')
 
     def _do_failover(self, old_primary=None):
         if not self.zk.delete_failover_state():
@@ -1777,9 +1731,12 @@ class pgconsul(object):
             logging.error("Can't get replics_info from ZK. Won't wait for timeout.")
             return False
 
-        if replica_infos is not None and (pgconsul._is_caught_up(replica_infos) and self.db.check_walreceiver()):
-            logging.debug('PostgreSQL has started streaming from {}'.format(primary))
-            return True
+        try:
+            if replica_infos is not None and (pgconsul._is_caught_up(replica_infos) and self.db.check_walreceiver()):
+                logging.debug('PostgreSQL has started streaming from {}'.format(primary))
+                return True
+        except PostgresConnectionError:
+            logging.warning('DB connection lost during streaming check')
 
         return None
 
@@ -1933,7 +1890,11 @@ class pgconsul(object):
     def _all_side_replicas_turned_to_the_candidate(self, side_replicas):
         side_replicas_app_names = {helpers.app_name_from_fqdn(r) for r in side_replicas}
         logging.debug('Side replicas names: %s', side_replicas_app_names)
-        replics_info = self.db.get_replics_info('replica')
+        try:
+            replics_info = self.db.get_replics_info('replica')
+        except PostgresConnectionError:
+            logging.warning('Could not get replics info from candidate, assuming not all replicas turned yet')
+            return False
         turned_replicas_names = set()
         for r in replics_info:
             if r['application_name'] in side_replicas_app_names and r['state'] == 'streaming':
@@ -1984,13 +1945,20 @@ class pgconsul(object):
         ):
             return False
 
-        # update replics info in ZK to avoid missguiding CLI
-        db_state['replics_info'] = self.db.get_replics_info('primary')
-        self._store_replics_info(db_state, zk_state)
+        # update replics info in ZK to avoid missguiding CLI (cosmetic, do not abort switchover on failure)
+        try:
+            db_state['replics_info'] = self.db.get_replics_info('primary')
+            self._store_replics_info(db_state, zk_state)
+        except PostgresConnectionError:
+            logging.warning('Could not update replics info in ZK during switchover, continuing')
 
         # Deny user requests
         logging.warning('Starting checkpoint')
-        self.db.checkpoint()
+        # checkpoint here is cosmetic (pooler is stopped next); do not abort switchover on DB error.
+        try:
+            self.db.checkpoint()
+        except PostgresConnectionError:
+            logging.warning('Could not checkpoint before switchover, continuing')
 
         self._start_timing('downtime')
 
@@ -2057,18 +2025,30 @@ class pgconsul(object):
         deadline = time.time() + timeout
         attempt = 0
         while time.time() < deadline:
-            replics_info = self.db.get_replics_info('primary')
-            if replics_info is None:
+            if not self.db.is_alive():
+                # Primary is unreachable — count attempts and eventually continue switchover
                 attempt += 1
-                logging.error('Failed to get replics info from old primary')
+                logging.warning('Failed to get replics info from old primary')
                 if attempt >= max_attempts:
                     logging.error('Old primary seems dead, continue switchover')
                     return True
-            elif self._candidate_is_sync_with_primary(replics_info, switchover_candidate):
-                logging.info('Candidate is in sync with old primary, continue switchover')
-                return True
+            else:
+                try:
+                    replics_info = self.db.get_replics_info('primary')
+                except PostgresConnectionError:
+                    # Treat DB connection loss same as primary being unreachable
+                    attempt += 1
+                    logging.warning('DB connection lost while waiting for candidate sync, treating as primary unreachable')
+                    if attempt >= max_attempts:
+                        logging.error('Old primary seems dead, continue switchover')
+                        return True
+                    time.sleep(self.config.getfloat('global', 'iteration_timeout'))
+                    continue
+                if self._candidate_is_sync_with_primary(replics_info, switchover_candidate):
+                    logging.info('Candidate is in sync with old primary, continue switchover')
+                    return True
             time.sleep(self.config.getfloat('global', 'iteration_timeout'))
-        logging.error('Candidate failed to catchup primary within %d secods', timeout)
+        logging.error('Candidate failed to catchup primary within %d seconds', timeout)
         return False
 
     def _candidate_is_sync_with_primary(self, replics_info, switchover_candidate):

--- a/src/main.py
+++ b/src/main.py
@@ -1212,7 +1212,7 @@ class pgconsul(object):
             if self.db.start_postgresql() != 0:
                 logging.error('Could not start PostgreSQL. Skipping it.')
 
-        logging.debug('Waiting for recovery and archive recovery')
+        logging.debug('Waiting for recovery and archive recovery. Limit is {} seconds'.format(limit))
         if self._wait_for_recovery(new_primary, limit):
             self.db.ensure_replaying_wal()
             if self._check_archive_recovery(new_primary, limit):            #
@@ -1230,6 +1230,11 @@ class pgconsul(object):
                     self._reset_simple_primary_switch_try()
                     return True
                 else:
+                    logging.warning(
+                        'Streaming from %s did not start within timeout.',
+                        new_primary,
+                    )
+                    self._set_simple_primary_switch_try()
                     return False
 
     def _rewind_from_source(self, is_postgresql_dead, limit, new_primary):
@@ -1273,7 +1278,9 @@ class pgconsul(object):
             return None
 
         if self.db.start_postgresql() != 0:
-            logging.error('Could not start PostgreSQL. Skipping it.')
+            logging.error('Could not start PostgreSQL. Will retry on next iteration.')
+            self._reset_simple_primary_switch_try()
+            return None
 
         if not self._wait_for_recovery(new_primary, limit):
             self._reset_simple_primary_switch_try()
@@ -1533,12 +1540,20 @@ class pgconsul(object):
             logging.warning('Promote is not allowed with given configuration.')
             return False
 
+        # Capture receive LSN before pausing WAL replay (walreceiver is still active here).
+        # Fall back to 0 on DB error: we still want to proceed with failover, just with lower LSN priority.
+        try:
+            wal_lsn = self.db.get_wal_receive_lsn()
+        except PostgresConnectionError:
+            logging.warning('Could not get WAL receive LSN before election, using 0.')
+            wal_lsn = '0'
+
         if not self.db.pg_wal_replay_pause():
             return False
 
-        return self._make_election(replica_infos, allow_data_loss)
+        return self._make_election(replica_infos, allow_data_loss, wal_lsn)
 
-    def _make_election(self, replica_infos: ReplicaInfos, allow_data_loss: bool) -> bool:
+    def _make_election(self, replica_infos: ReplicaInfos, allow_data_loss: bool, wal_lsn: str) -> bool:
         election_timeout = self.config.getint('global', 'election_timeout')
         quorum_size = len(helpers.make_current_replics_quorum(replica_infos, self.zk.get_alive_hosts(all_hosts_timeout=election_timeout / 3)))
         election = FailoverElection(
@@ -1548,7 +1563,7 @@ class pgconsul(object):
             self._replication_manager,
             allow_data_loss,
             self.config.getint('global', 'priority'),
-            self.db.get_wal_receive_lsn(),
+            wal_lsn,
             quorum_size,
         )
         try:
@@ -1617,7 +1632,7 @@ class pgconsul(object):
             self.zk.write_last_failover_time()
             self._stop_timing('failover')
         except PostgresConnectionError:
-            logging.warning('DB connection lost during failover checks. Aborting failover.')
+            logging.exception('DB connection lost during failover checks. Aborting failover.')
             return None
 
     def _do_failover(self, old_primary=None):

--- a/src/pg.py
+++ b/src/pg.py
@@ -20,6 +20,7 @@ from psycopg2.sql import SQL, Identifier
 
 from . import helpers
 from .command_manager import CommandManager
+from .exceptions import PostgresConnectionError
 from .types import ReplicaInfos
 
 DEC2INT_TYPE = psycopg2.extensions.new_type(
@@ -105,9 +106,9 @@ class Postgres(object):
         cur = self._create_cursor()
         try:
             cur.execute(query, kwargs)
-        except psycopg2.OperationalError:
+        except psycopg2.OperationalError as exc:
             self.close()
-            raise
+            raise PostgresConnectionError(str(exc)) from exc
         return cur
 
     def _get(self, query, **kwargs):
@@ -116,12 +117,13 @@ class Postgres(object):
             return records
 
     def _exec_without_result(self, query):
-        try:
-            self._exec_query(query)
-            return True
-        except Exception:
-            logging.exception('Error executing query without result')
-            return False
+        """Execute a query, ignoring the result.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
+        self._exec_query(query)
+        return True
 
     def _get_data_from_control_file(self, parameter, preproc=None, log=True):
         """
@@ -174,10 +176,14 @@ class Postgres(object):
         except Exception:
             logging.exception('Error getting database state')
 
-    @helpers.return_none_on_error
-    def get_replication_slots(self):
-        res = self._exec_query('SELECT slot_name FROM pg_replication_slots;').fetchall()
-        return [i[0] for i in res]
+    def get_replication_slots(self) -> list[str]:
+        """Get names of all replication slots.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
+        rows = self._get('SELECT slot_name FROM pg_replication_slots')
+        return [r['slot_name'] for r in rows]
 
     def _create_replication_slot(self, slot_name):
         logging.debug('ACTION. Creating slot %s.', slot_name)
@@ -206,6 +212,10 @@ class Postgres(object):
             self.conn_local = None
             if any(e in str(err) for e in TRANSIENT_ERRORS):
                 self.terminal_state = False
+        except PostgresConnectionError:
+            # _get_pgdata_path failed after connection was established
+            logging.exception('Could not get pgdata path after reconnect to "%s".', self.config.conn_string)
+            self.conn_local = None
 
     def close(self):
         """
@@ -255,6 +265,7 @@ class Postgres(object):
                 data['alive'] = self.is_alive()
         except Exception:
             logging.exception('Error getting database state')
+            data['alive'] = False
 
         if not data['alive']:
             logging.error('PostgreSQL is dead')
@@ -318,7 +329,6 @@ class Postgres(object):
             logging.exception('failed to get postgresql role')
             return None
 
-    @helpers.return_none_on_error
     def _get_pgdata_path(self):
         """
         Get local pg_data
@@ -326,10 +336,11 @@ class Postgres(object):
         res = self._exec_query('SHOW data_directory;').fetchone()
         return res[0]
 
-    @helpers.return_none_on_error
-    def get_replics_info(self, role) -> ReplicaInfos | None:
-        """
-        Get replicas from pg_stat_replication
+    def get_replics_info(self, role) -> ReplicaInfos:
+        """Get replicas from pg_stat_replication.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
         """
         current_lsn = {'primary': 'pg_current_wal_lsn()', 'replica': 'pg_last_wal_replay_lsn()'}
         wal_func = {
@@ -369,10 +380,11 @@ class Postgres(object):
         )
         return self._get(query)
 
-    @helpers.return_none_on_error
     def _get_wal_receiver_info(self):
-        """
-        Get wal_receiver info from pg_stat_wal_receiver
+        """Get wal_receiver info from pg_stat_wal_receiver.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
         """
         query = """SELECT pid, status, slot_name,
                    COALESCE(1000*EXTRACT(epoch FROM last_msg_receipt_time), 0)::bigint AS last_msg_receipt_time_msec,
@@ -380,27 +392,29 @@ class Postgres(object):
         result = self._get(query)
         if result:
             return result[0]
+        return None
 
-    @helpers.return_none_on_error
     def get_replication_state(self):
-        """
-        Get replication type (sync/async)
+        """Get replication type (sync/async).
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
         """
         res = self._exec_query('SHOW synchronous_standby_names;').fetchone()
         res = ('async', None) if res[0] == '' else ('sync', res[0])
         return res
 
-    @helpers.return_none_on_error
     def get_sessions_ratio(self):
-        """
-        Get ratio of active sessions/max sessions (in percents)
+        """Get ratio of active sessions/max sessions (in percents).
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
         """
         cur = self._exec_query("SELECT count(*) FROM pg_stat_activity WHERE state!='idle';")
         cur = cur.fetchone()[0]
         max_sessions = self._exec_query('SHOW max_connections;').fetchone()[0]
         return (cur / int(max_sessions)) * 100
 
-    @helpers.return_none_on_error
     def lwaldump(self):
         """Protected from kill -9 postgres"""
         query = """SELECT pg_wal_lsn_diff(
@@ -408,8 +422,12 @@ class Postgres(object):
                 '0/00000000')::bigint"""
         return self._exec_query(query).fetchone()[0]
 
-    @helpers.return_none_on_error
     def get_wal_receive_lsn(self):
+        """Get WAL receive LSN as an integer offset.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
         if self.config.use_lwaldump:
             return self.lwaldump()
         query = """SELECT pg_wal_lsn_diff(
@@ -418,31 +436,27 @@ class Postgres(object):
         return self._exec_query(query).fetchone()[0]
 
     def check_walsender(self, replics_info: ReplicaInfos, holder_fqdn):
-        """
-        Check walsender in sync state and sync holder is same
-        """
+        """Check walsender in sync state and sync holder is same."""
         if not replics_info:
             return True
         holder_app_name = helpers.app_name_from_fqdn(holder_fqdn)
         for replica in replics_info:
-            try:
-                if replica['sync_state'] == 'sync' and replica['application_name'] != holder_app_name:
-                    logging.warning('It seems sync replica and sync replica holder are different. Killing walsender.')
+            if replica['sync_state'] == 'sync' and replica['application_name'] != holder_app_name:
+                logging.warning('It seems sync replica and sync replica holder are different. Killing walsender.')
+                try:
                     os.kill(int(replica['pid']), signal.SIGTERM)
-                    break
-            except Exception as exc:
-                logging.error('Check walsender error: %s', repr(exc))
+                except (ValueError, ProcessLookupError, PermissionError) as exc:
+                    logging.error('Check walsender error: %s', repr(exc))
+                break
         return True
 
-    def check_walreceiver(self):
+    def check_walreceiver(self) -> bool:
+        """Check if walreceiver is running via pg_stat_wal_receiver.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
         """
-        Check if walreceiver is running using pg_stat_wal_receiver view
-        """
-        try:
-            cur = self._exec_query('SELECT pid FROM pg_stat_wal_receiver WHERE status = \'streaming\'')
-        except Exception as exc:
-            logging.error('Unable to get walreceiver state: %s', repr(exc))
-            return False
+        cur = self._exec_query('SELECT pid FROM pg_stat_wal_receiver WHERE status = \'streaming\'')
         return bool(cur.fetchall())
 
     def is_ready_for_pg_rewind(self):
@@ -462,8 +476,12 @@ class Postgres(object):
         logging.error("Checksums or wal_log_hints should be enabled for pg_rewind to work properly.")
         return False
 
-    @helpers.return_none_on_error
     def get_replay_diff(self, diff_from='0/00000000'):
+        """Get WAL replay LSN diff from the given base LSN.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
         query = f"""SELECT pg_wal_lsn_diff(
                 pg_last_wal_replay_lsn(),
                 '{diff_from}')::bigint"""
@@ -668,33 +686,31 @@ class Postgres(object):
         return value
 
     def _alter_system_set_param(self, param: str, value=None, reset=False) -> bool:
+        """Set or reset a PostgreSQL parameter via ALTER SYSTEM.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
         def equal() -> bool:
             return self._get_param_value(param) == value
 
         def unequal(prev_value) -> bool:
             return self._get_param_value(param) != prev_value
 
-        if self.conn_local is None:
-            logging.error("No database connection")
-            return False
+        if reset:
+            prev_value = self._get_param_value(param)
+            logging.info(f'ACTION. Resetting {param} with ALTER SYSTEM')
+            query = SQL("ALTER SYSTEM RESET {param}").format(param=Identifier(param))
+            self._exec_query(query)
+            await_func: Callable[[], bool] = partial(unequal, prev_value)
+            await_message = f'{param} is reset after reload'
+        else:
+            logging.info(f'ACTION. Setting {param} to {value} with ALTER SYSTEM')
+            query = SQL("ALTER SYSTEM SET {param} TO %(value)s").format(param=Identifier(param))
+            self._exec_query(query, value=value)
+            await_func = equal
+            await_message = f'{param} is set to {value} after reload'
 
-        try:
-            if reset:
-                prev_value = self._get_param_value(param)
-                logging.info(f'ACTION. Resetting {param} with ALTER SYSTEM')
-                query = SQL("ALTER SYSTEM RESET {param}").format(param=Identifier(param))
-                self._exec_query(query.as_string(self.conn_local))
-                await_func: Callable[[], bool] = partial(unequal, prev_value)
-                await_message = f'{param} is reset after reload'
-            else:
-                logging.info(f'ACTION. Setting {param} to {value} with ALTER SYSTEM')
-                query = SQL("ALTER SYSTEM SET {param} TO %(value)s").format(param=Identifier(param))
-                self._exec_query(query.as_string(self.conn_local), value=value)
-                await_func = equal
-                await_message = f'{param} is set to {value} after reload'
-        except Exception:
-            logging.exception('Error setting PostgreSQL parameter')
-            return False
         reload_result = self._cmd_manager.reload_postgresql(self.pgdata)
         if reload_result:
             logging.debug(f'Reload has failed, not waiting for param {param} change')
@@ -801,8 +817,11 @@ class Postgres(object):
             return False
 
     def checkpoint(self, query=None):
-        """
-        Perform checkpoint
+        """Perform checkpoint.
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost (propagates
+                from _exec_without_result to the caller).
         """
         logging.info('ACTION. Initiating checkpoint')
         if not query:
@@ -829,34 +848,6 @@ class Postgres(object):
         """
         return self._cmd_manager.stop_postgresql(timeout, self.pgdata, wait=wait)
 
-    def create_replication_slots(self, slots: list[str], verbose=True):
-        if len(slots) == 0:
-            return True
-        logging.info('Creating slots: %s', slots)
-        current = self.get_replication_slots()
-        for slot in slots:
-            if current and slot in current:
-                if verbose:
-                    logging.debug('Slot %s already exists.', slot)
-                continue
-            if not self._create_replication_slot(slot):
-                return False
-        return True
-
-    def drop_replication_slots(self, slots, verbose=True):
-        if len(slots) == 0:
-            return True
-        logging.info('ACTION. Dropping slots: %s', slots)
-        current = self.get_replication_slots()
-        for slot in slots:
-            if current is not None and slot not in current:
-                if verbose:
-                    logging.debug('Slot %s does not exist.', slot)
-                continue
-            if not self._drop_replication_slot(slot):
-                return False
-        return True
-
     def is_replaying_wal(self, check_time):
         prev_replay_diff = self.get_replay_diff()
         time.sleep(check_time)
@@ -864,17 +855,21 @@ class Postgres(object):
         return prev_replay_diff < replay_diff
 
     def pg_wal_replay_pause(self) -> bool:
+        """Pause WAL replay after disabling walreceiver.
+
+        Returns False if pg_wal_replay_pause() cannot be executed after
+        promotion is triggered (ObjectNotInPrerequisiteState).
+
+        Raises:
+            PostgresConnectionError: if the DB connection is lost (propagates
+                to _accept_failover boundary).
+        """
         try:
-            if self._disable_wal_receiver():
-                self._pg_wal_replay("pause")
+            self._disable_wal_receiver()
+            self._pg_wal_replay("pause")
         except psycopg2.errors.ObjectNotInPrerequisiteState as exc:
             # pg_wal_replay_pause() cannot be executed after promotion is triggered
-            # so we just leave iteration
             logging.error('Could not replay pause. %s', str(exc))
-            return False
-        except Exception as exc:
-            logging.error('Could not replay pause. Unexpected error.')
-            logging.exception(exc)
             return False
         return True
 
@@ -891,20 +886,18 @@ class Postgres(object):
         self.pg_wal_replay_resume()
 
     def _disable_wal_receiver(self):
-        """
-        Disable walreceiver
-        """
-        try:
-            if self._exec_query('SHOW primary_conninfo;').fetchone()[0] == '':
-                logging.debug('walreceiver is already disabled')
+        """Disable walreceiver by clearing primary_conninfo.
 
-            logging.info('ACTION. Disabling walreceiver.')
+        Raises:
+            PostgresConnectionError: if the DB connection is lost.
+        """
+        if self._exec_query('SHOW primary_conninfo;').fetchone()[0] == '':
+            logging.debug('walreceiver is already disabled')
 
-            self._alter_system_set_param('primary_conninfo', '')
-            self.reload()
-        except Exception as exc:
-            logging.error('Could not disable walreceiver. Unexpected error.')
-            logging.exception(exc)
+        logging.info('ACTION. Disabling walreceiver.')
+
+        self._alter_system_set_param('primary_conninfo', '')
+        self.reload()
 
     def enable_wal_receiver_if_disabled(self):
         """
@@ -931,12 +924,16 @@ class Postgres(object):
         return self._get_param_value('primary_conninfo') == ''
 
     def terminate_backend(self, pid):
+        """Send sigterm to backend by pid.
+
+        Result is not checked — pid may be already dead by this moment.
+        A lost DB connection is logged and swallowed (fire-and-forget) so a
+        stale pid does not abort the iteration.
         """
-        Send sigterm to backend by pid
-        """
-        # Note that pid could be already dead by this moment
-        # So we do not check result
-        self._exec_without_result(f'SELECT pg_terminate_backend({pid})')
+        try:
+            self._exec_without_result(f'SELECT pg_terminate_backend({pid})')
+        except PostgresConnectionError:
+            logging.warning('Could not terminate backend %s: DB connection lost', pid)
 
     def _pg_wal_replay(self, pause_or_resume):
         logging.info('ACTION. WAL replay: %s', pause_or_resume)

--- a/src/replication_manager.py
+++ b/src/replication_manager.py
@@ -111,13 +111,13 @@ class ReplicationManager:
             info = self._db.get_replics_info(self._db.role)
             should_wait = False
             for replica in info:
-                if replica['reply_time_ms'] / 1000 < self._zk_fail_timestamp:
+                if int(replica['reply_time_ms']) / 1000 < self._zk_fail_timestamp:
                     should_wait = True
             if should_wait:
                 time.sleep(self._config.primary_unavailability_timeout)
                 info = self._db.get_replics_info(self._db.role)
 
-            connected = sum([1 for x in info if x['sync_state'] == 'quorum' and x['reply_time_ms'] / 1000 > self._zk_fail_timestamp])
+            connected = sum([1 for x in info if x['sync_state'] == 'quorum' and int(x['reply_time_ms']) / 1000 > self._zk_fail_timestamp])
             repl_state = self._db.get_replication_state()
             if repl_state[0] == 'async':
                 return False

--- a/src/slot_manager.py
+++ b/src/slot_manager.py
@@ -1,0 +1,197 @@
+# encoding: utf-8
+"""
+Replication slot manager module.
+
+Encapsulates all logic for creating, dropping and synchronizing
+PostgreSQL physical replication slots based on ZooKeeper state.
+"""
+import logging
+import os
+
+from configparser import RawConfigParser
+from dataclasses import dataclass
+
+from . import helpers
+from .exceptions import PostgresConnectionError
+from .pg import Postgres
+from .zk import Zookeeper
+
+
+@dataclass
+class ReplicationSlotManagerConfig:
+    """Configuration for ReplicationSlotManager."""
+    replication_slots_polling: bool
+    use_replication_slots: bool
+    drop_slot_countdown: int
+
+
+class ReplicationSlotManager:
+    """
+    Manage PostgreSQL replication slots lifecycle.
+    """
+
+    def __init__(self, db: Postgres, zk: Zookeeper, config: ReplicationSlotManagerConfig):
+        self._db = db
+        self._zk = zk
+        self._config = config
+        self._drop_countdown: dict[str, int] = {}
+
+    def handle_slots(self) -> None:
+        """
+        Synchronize replication slots with ZK state.
+        Called from primary_iter, replica_iter and non_ha_replica_iter.
+        """
+        if not self._config.replication_slots_polling:
+            return
+
+        my_hostname = helpers.get_hostname()
+        try:
+            slot_lock_holders = set(
+                self._zk.get_lock_contenders(
+                    os.path.join(self._zk.HOST_REPLICATION_SOURCES, my_hostname),
+                    read_lock=True,
+                    catch_except=False,
+                )
+            )
+        except Exception as e:
+            logging.warning(
+                'Could not get slot lock holders. %s'
+                'Can not handle replication slots. We will skip it this time', e
+            )
+            return
+
+        all_hosts = self._zk.get_members()
+        if not all_hosts:
+            logging.warning(
+                'Could not get all hosts list from ZK.'
+                'Can not handle replication slots. We will skip it this time'
+            )
+            return
+
+        non_holders_hosts = self._compute_non_holders(all_hosts, slot_lock_holders)
+
+        # Do not drop our own slot
+        if my_hostname in non_holders_hosts:
+            non_holders_hosts.remove(my_hostname)
+
+        slot_names_to_create = [helpers.app_name_from_fqdn(fqdn) for fqdn in slot_lock_holders]
+        slot_names_to_drop = [helpers.app_name_from_fqdn(fqdn) for fqdn in non_holders_hosts]
+
+        try:
+            create_ok, drop_ok = self._sync_slots(slot_names_to_create, slot_names_to_drop)
+        except PostgresConnectionError:
+            # Slot sync is best-effort: a lost DB connection is not fatal here,
+            # the next iteration will retry. exc_info preserves traceback for diagnostics.
+            logging.warning('Could not get replication slots from DB. Skipping slot handling this time', exc_info=True)
+            return
+
+        if not create_ok:
+            logging.warning('Could not create replication slots. %s', slot_names_to_create)
+        if not drop_ok:
+            logging.warning('Could not drop replication slots. %s', slot_names_to_drop)
+
+    def _sync_slots(self, to_create: list[str], to_drop: list[str]) -> tuple[bool, bool]:
+        """Create and drop replication slots in a single pass.
+
+        Fetches the current slot list once and reuses it for both operations.
+        Returns (create_ok, drop_ok).
+
+        Raises:
+            PostgresConnectionError: from get_replication_slots; caught by handle_slots.
+        """
+        current = self._db.get_replication_slots()
+        create_ok = self._create_missing(to_create, current=current, fail_fast=False)
+
+        drop_ok = True
+        for slot in to_drop:
+            if slot not in current:
+                continue
+            try:
+                self._db._drop_replication_slot(slot)
+            except PostgresConnectionError:
+                logging.warning('Failed to drop slot %s', slot, exc_info=True)
+                drop_ok = False
+
+        return create_ok, drop_ok
+
+    def _create_missing(self, slots: list[str], current: list[str], fail_fast: bool) -> bool:
+        """Create missing replication slots.
+
+        When fail_fast is True, returns False on the first DB failure
+        (failover/switchover path). Otherwise accumulates the result
+        (periodic synchronization).
+        """
+        if not slots:
+            return True
+        logging.debug('Actual replication slots: %s', current)
+        ok = True
+        for slot in slots:
+            if slot in current:
+                continue
+            try:
+                self._db._create_replication_slot(slot)
+            except PostgresConnectionError:
+                logging.warning('Failed to create slot %s', slot, exc_info=True)
+                if fail_fast:
+                    return False
+                ok = False
+
+        return ok
+
+    def _compute_non_holders(self, all_hosts: list[str], slot_lock_holders: set[str]) -> list[str]:
+        """
+        Update countdown for each host and return hosts whose countdown expired.
+        """
+        countdown_default = self._config.drop_slot_countdown
+        non_holders_hosts: list[str] = []
+
+        for host in all_hosts:
+            if host in slot_lock_holders:
+                self._drop_countdown[host] = countdown_default
+            else:
+                if host not in self._drop_countdown:
+                    self._drop_countdown[host] = countdown_default
+                self._drop_countdown[host] -= 1
+                if self._drop_countdown[host] < 0:
+                    non_holders_hosts.append(host)
+
+        return non_holders_hosts
+
+    def create_slots_for_hosts(self, hosts: list[str]) -> bool:
+        """Create replication slots for the given list of host FQDNs.
+
+        Used during failover and switchover.
+
+        Raises:
+            PostgresConnectionError: propagated from get_replication_slots /
+                _create_replication_slot if the DB connection is lost.
+                Callers (failover/switchover) must handle or propagate it.
+        """
+        if not self._config.use_replication_slots:
+            return True
+        if not hosts:
+            return True
+        slot_names = [helpers.app_name_from_fqdn(fqdn) for fqdn in hosts]
+        current = self._db.get_replication_slots()
+        if not self._create_missing(slot_names, current, fail_fast=True):
+            logging.error('Could not create replication slots. Releasing the lock in ZK.')
+            return False
+        return True
+
+    def reset_on_promote(self) -> None:
+        """
+        Reset the drop countdown after a promote.
+        """
+        self._drop_countdown = {}
+
+
+def create_replication_slot_manager(
+    config: RawConfigParser, db: Postgres, zk: Zookeeper
+) -> ReplicationSlotManager:
+    """Factory: create ReplicationSlotManager from config object."""
+    slot_config = ReplicationSlotManagerConfig(
+        replication_slots_polling=config.getboolean('global', 'replication_slots_polling'),
+        use_replication_slots=config.getboolean('global', 'use_replication_slots'),
+        drop_slot_countdown=config.getint('global', 'drop_slot_countdown'),
+    )
+    return ReplicationSlotManager(db, zk, slot_config)

--- a/tests/features/failover_with_network_inconsistency.feature
+++ b/tests/features/failover_with_network_inconsistency.feature
@@ -9,7 +9,7 @@ Feature: Failover with network inconsistency
                     priority: 0
                     use_replication_slots: 'yes'
                     max_rewind_retries: 3
-                    election_timeout: 5
+                    election_timeout: 10
                     update_prio_in_zk: 'yes'
                     autofailover: 'yes'
                     quorum_commit: 'yes'
@@ -65,13 +65,21 @@ Feature: Failover with network inconsistency
         # Wait until Election is done
         Then zookeeper "zookeeper1" has value "done" for key "/pgconsul/postgresql/election_status"
         # Return connectivity between postgresql1 and postgresql3. Host postgresql3 will stay a replica
+        When we switch wal in "postgresql1" "5" times
         When we unblock postgres traffic from "postgresql1" to "postgresql3"
+        # Force postgresql1 to generate fresh WAL while postgresql3's walreceiver is reconnecting.
+        # This guarantees postgresql3's LSN ends up ahead of postgresql2's promote point (WAL divergence).
+        When we switch wal in "postgresql1" "5" times
         Then container "postgresql2" became a primary
         Then container "postgresql3" is a replica of container "postgresql2" and streaming
+        # for log_min_messages = debug5
+        # And postgresql in container "postgresql3" was rewinded
+        # for log_min_messages = info
+        # And postgresql in container "postgresql3" was not rewinded
         When we connect to ZK container "postgresql1"
         When we run following command on host "postgresql1"
         """
         sh -c "iptables -F"
         """
         Then container "postgresql1" is a replica of container "postgresql2" and streaming
-        Then container "postgresql3" is a replica of container "postgresql2" and streaming
+        And postgresql in container "postgresql1" was rewinded

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,6 +29,15 @@ for _mod_name in (
     if _mod_name not in sys.modules:
         sys.modules[_mod_name] = MagicMock()
 
+# Stub psycopg2 with real exception classes so that
+# `except psycopg2.OperationalError` etc. work correctly in unit tests.
+if 'psycopg2' in sys.modules:
+    _psycopg2 = sys.modules['psycopg2']
+    _psycopg2.Error = type('Error', (Exception,), {})
+    _psycopg2.OperationalError = type('OperationalError', (_psycopg2.Error,), {})
+    _psycopg2.DatabaseError = type('DatabaseError', (_psycopg2.Error,), {})
+    _psycopg2.InterfaceError = type('InterfaceError', (_psycopg2.Error,), {})
+
 # Stub kazoo.exceptions with real exception classes so that
 # `except KazooException` / `except NoNodeError` etc. work in unit tests.
 if 'kazoo.exceptions' not in sys.modules:

--- a/tests/unit/test_main_switchover.py
+++ b/tests/unit/test_main_switchover.py
@@ -1,0 +1,562 @@
+# encoding: utf-8
+"""
+Unit tests for switchover and failover methods in src/main.py.
+
+Tests cover:
+  - _wait_candidate_is_sync_with_primary: uses is_alive() instead of None-check
+  - _candidate_is_sync_with_primary: replay lag logic
+  - _accept_failover: PostgresConnectionError returns None; unexpected errors propagate
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+def _make_pgconsul():
+    """
+    Create a pgconsul instance bypassing __init__ entirely.
+
+    We patch __init__ to do nothing, then inject the minimal attributes
+    needed by the methods under test.
+    """
+    with patch('src.main.pgconsul.__init__', return_value=None):
+        from src.main import pgconsul as PgConsul
+        inst = PgConsul.__new__(PgConsul)
+
+    # Minimal mocks required by _wait_candidate_is_sync_with_primary
+    inst.db = MagicMock()
+    inst.config = MagicMock()
+    # iteration_timeout controls sleep between attempts
+    inst.config.getfloat.return_value = 0.0  # instant sleep in tests
+    # max_allowed_switchover_lag_ms — used by _candidate_is_sync_with_primary
+    inst.config.getint.return_value = 0
+    inst.config.getboolean.return_value = False
+
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# Tests: _candidate_is_sync_with_primary
+# ---------------------------------------------------------------------------
+
+class TestCandidateIsSyncWithPrimary:
+    """_candidate_is_sync_with_primary checks replay lag for the candidate."""
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.config = MagicMock()
+        return inst
+
+    def _replica_info(self, app_name='replica1', replay_lag_msec=0):
+        return {
+            'application_name': app_name,
+            'state': 'streaming',
+            'replay_lag_msec': replay_lag_msec,
+        }
+
+    def test_returns_true_when_lag_within_limit(self):
+        """Returns True when replay lag is within the allowed limit."""
+        inst = self._make()
+        inst.config.getint.return_value = 100  # 100ms allowed
+        inst.config.getboolean.return_value = False
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._candidate_is_sync_with_primary(
+                [self._replica_info('replica1', replay_lag_msec=50)],
+                'replica1.example.com',
+            )
+        assert result is True
+
+    def test_returns_false_when_lag_exceeds_limit(self):
+        """Returns False when lag exceeds limit and data loss not allowed."""
+        inst = self._make()
+        inst.config.getint.return_value = 100  # 100ms allowed
+        inst.config.getboolean.return_value = False  # allow_potential_data_loss=False
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._candidate_is_sync_with_primary(
+                [self._replica_info('replica1', replay_lag_msec=200)],
+                'replica1.example.com',
+            )
+        assert result is False
+
+    def test_returns_true_when_lag_exceeds_but_data_loss_allowed(self):
+        """Returns True when lag is high but allow_potential_data_loss=True."""
+        inst = self._make()
+        inst.config.getint.return_value = 100
+        inst.config.getboolean.return_value = True  # allow_potential_data_loss=True
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._candidate_is_sync_with_primary(
+                [self._replica_info('replica1', replay_lag_msec=999)],
+                'replica1.example.com',
+            )
+        assert result is True
+
+    def test_returns_false_when_candidate_not_in_replics_info(self):
+        """Returns False when candidate is not in replics_info."""
+        inst = self._make()
+        inst.config.getint.return_value = 100
+        inst.config.getboolean.return_value = False
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._candidate_is_sync_with_primary(
+                [],  # empty list — no replicas
+                'replica1.example.com',
+            )
+        assert result is False
+
+    def test_returns_false_when_replay_lag_is_none(self):
+        """Returns False when replay_lag_msec is missing."""
+        inst = self._make()
+        inst.config.getint.return_value = 100
+        inst.config.getboolean.return_value = False
+
+        info = {'application_name': 'replica1', 'state': 'streaming', 'replay_lag_msec': None}
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._candidate_is_sync_with_primary([info], 'replica1.example.com')
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _wait_candidate_is_sync_with_primary
+# ---------------------------------------------------------------------------
+
+class TestWaitCandidateIsSyncWithPrimary:
+    """
+    _wait_candidate_is_sync_with_primary should:
+    - Return True when candidate catches up
+    - Return True when primary becomes unreachable after max_attempts
+    - Return False when timeout expires without sync
+    """
+
+    def _make(self):
+        inst = _make_pgconsul()
+        return inst
+
+    def _replica_info(self, app_name='replica1', replay_lag_msec=0):
+        return {
+            'application_name': app_name,
+            'state': 'streaming',
+            'replay_lag_msec': replay_lag_msec,
+        }
+
+    def test_returns_true_when_candidate_synced(self):
+        """Returns True immediately when candidate is in sync."""
+        inst = self._make()
+        inst.db.is_alive.return_value = True
+        inst.db.get_replics_info.return_value = [self._replica_info('replica1', 0)]
+        inst.config.getint.return_value = 1000  # 1000ms allowed lag
+        inst.config.getboolean.return_value = False
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'), \
+             patch('time.time', side_effect=[0.0, 0.0] + [100.0] * 20):  # deadline far away
+            result = inst._wait_candidate_is_sync_with_primary(
+                'replica1.example.com', timeout=60
+            )
+        assert result is True
+
+    def test_returns_true_when_primary_unreachable_after_max_attempts(self):
+        """Returns True when primary is unreachable for max_attempts iterations."""
+        inst = self._make()
+        # is_alive always returns False — primary is unreachable
+        inst.db.is_alive.return_value = False
+        inst.config.getint.return_value = 0  # not used in this path
+        inst.config.getboolean.return_value = False
+
+        # Provide enough time values for the loop to run max_attempts=5 times
+        time_values = [0.0] * 20 + [1000.0]  # deadline always far
+        with patch('time.time', side_effect=time_values):
+            result = inst._wait_candidate_is_sync_with_primary(
+                'replica1.example.com', timeout=60, max_attempts=3
+            )
+        assert result is True
+
+    def test_returns_false_when_timeout_expires(self):
+        """Returns False when candidate never syncs within timeout."""
+        inst = self._make()
+        # primary is alive but lag is too high
+        inst.db.is_alive.return_value = True
+        inst.db.get_replics_info.return_value = [
+            self._replica_info('replica1', replay_lag_msec=99999)
+        ]
+        inst.config.getint.return_value = 0  # 0ms allowed — lag always exceeds
+        inst.config.getboolean.return_value = False
+
+        # Simulate timeout expiry: first calls are 0.0, then beyond deadline.
+        # Extra values absorb time.time() calls made by logging on some Python versions.
+        with patch('time.time', side_effect=[0.0, 0.0] + [100.0] * 20), \
+             patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._wait_candidate_is_sync_with_primary(
+                'replica1.example.com', timeout=50, max_attempts=5
+            )
+        assert result is False
+
+    def test_primary_alive_calls_get_replics_info(self):
+        """When primary is alive, get_replics_info is called to check sync."""
+        inst = self._make()
+        inst.db.is_alive.return_value = True
+        inst.db.get_replics_info.return_value = [self._replica_info('replica1', 0)]
+        inst.config.getint.return_value = 9999
+        inst.config.getboolean.return_value = False
+
+        with patch('src.helpers.app_name_from_fqdn', return_value='replica1'), \
+             patch('time.time', side_effect=[0.0, 0.0] + [100.0] * 20):
+            inst._wait_candidate_is_sync_with_primary('replica1.example.com', timeout=60)
+
+        inst.db.get_replics_info.assert_called_once_with('primary')
+
+    def test_primary_dead_does_not_call_get_replics_info(self):
+        """When primary is unreachable, get_replics_info is never called."""
+        inst = self._make()
+        inst.db.is_alive.return_value = False
+        inst.config.getint.return_value = 0
+        inst.config.getboolean.return_value = False
+
+        time_values = [0.0] * 20 + [1000.0]
+        with patch('time.time', side_effect=time_values):
+            inst._wait_candidate_is_sync_with_primary(
+                'replica1.example.com', timeout=60, max_attempts=1
+            )
+
+        inst.db.get_replics_info.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _all_side_replicas_turned_to_the_candidate
+# ---------------------------------------------------------------------------
+
+class TestAllSideReplicasTurnedToTheCandidate:
+    """_all_side_replicas_turned_to_the_candidate returns False on DB error."""
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        return inst
+
+    def test_returns_true_when_all_replicas_turned(self):
+        """Returns True when all side replicas are streaming from the candidate."""
+        inst = self._make()
+        inst.db.get_replics_info.return_value = [
+            {'application_name': 'replica2', 'state': 'streaming'},
+        ]
+        with patch('src.helpers.app_name_from_fqdn', side_effect=lambda x: x.split('.')[0]):
+            result = inst._all_side_replicas_turned_to_the_candidate(['replica2.example.com'])
+        assert result is True
+
+    def test_returns_false_on_connection_error(self):
+        """PostgresConnectionError → return False (await_for will retry)."""
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+        inst.db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        with patch('src.helpers.app_name_from_fqdn', side_effect=lambda x: x.split('.')[0]):
+            result = inst._all_side_replicas_turned_to_the_candidate(['replica2.example.com'])
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _wait_candidate_is_sync_with_primary — DB error path
+# ---------------------------------------------------------------------------
+
+class TestWaitCandidateConnectionError:
+    """_wait_candidate_is_sync_with_primary treats DB error like primary unreachable."""
+
+    def _make(self):
+        inst = _make_pgconsul()
+        return inst
+
+    def test_db_error_increments_attempt_like_dead_primary(self):
+        """PostgresConnectionError from get_replics_info → attempt++, eventually returns True."""
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+        inst.db.is_alive.return_value = True  # primary appears alive via is_alive
+        inst.db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        inst.config.getint.return_value = 0
+        inst.config.getboolean.return_value = False
+
+        # Enough time values to run max_attempts=1 iteration
+        time_values = [0.0] * 10 + [1000.0]
+        with patch('time.time', side_effect=time_values), \
+             patch('src.helpers.app_name_from_fqdn', return_value='replica1'):
+            result = inst._wait_candidate_is_sync_with_primary(
+                'replica1.example.com', timeout=60, max_attempts=1
+            )
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _accept_failover — PostgresConnectionError must not kill the process
+# ---------------------------------------------------------------------------
+
+class TestAcceptFailoverConnectionError:
+    """_accept_failover must not call sys.exit on PostgresConnectionError."""
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        from src.exceptions import PostgresConnectionError
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        inst.zk = MagicMock()
+        inst.config = MagicMock()
+        inst.config.getfloat.return_value = 0.0
+        inst.config.getint.return_value = 0
+        inst.config.getboolean.return_value = False
+        inst._master_lost_ts = 0.0
+        return inst
+
+    def test_returns_none_on_postgres_connection_error(self):
+        """PostgresConnectionError during failover checks → return None, no sys.exit."""
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+        inst._can_do_failover = MagicMock(side_effect=PostgresConnectionError("db down"))
+
+        with patch('sys.exit') as mock_exit:
+            result = inst._accept_failover(switchover_in_progress=False)
+
+        assert result is None
+        mock_exit.assert_not_called()
+
+    def test_propagates_unexpected_exception(self):
+        """Unexpected Exception (not PostgresConnectionError) → propagates to run_iteration()."""
+        inst = self._make()
+        inst._can_do_failover = MagicMock(side_effect=RuntimeError("unexpected"))
+
+        with patch('sys.exit') as mock_exit:
+            with pytest.raises(RuntimeError):
+                inst._accept_failover(switchover_in_progress=False)
+
+        mock_exit.assert_not_called()
+
+
+class TestGetStreamingReplicas:
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        inst.zk = MagicMock()
+        return inst
+
+    def test_raises_on_connection_error(self):
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+        inst.db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        with pytest.raises(PostgresConnectionError):
+            inst._get_streaming_replicas()
+
+    def test_returns_streaming_hosts(self):
+        inst = self._make()
+        inst.db.get_replics_info.return_value = [{'application_name': 'host1'}]
+        inst.zk.get_members.return_value = ['host1.example.com', 'host2.example.com']
+        with patch('src.helpers.app_name_from_fqdn', side_effect=lambda x: x.split('.')[0]):
+            result = inst._get_streaming_replicas()
+        assert result == ['host1.example.com']
+
+
+class TestCheckArchiveRecovery:
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        return inst
+
+    def test_returns_true_when_streaming(self):
+        inst = self._make()
+        with patch.object(inst, '_check_postgresql_streaming', return_value=True), \
+             patch('src.main.helpers.await_for_value', return_value=True):
+            result = inst._check_archive_recovery('primary.example.com', limit=10)
+        assert result is True
+
+    def test_returns_none_when_not_replaying(self):
+        inst = self._make()
+        inst.db.get_role.return_value = 'replica'
+        inst.db.is_replaying_wal.return_value = False
+        with patch.object(inst, '_check_postgresql_streaming', return_value=False), \
+             patch.object(inst, '_acquire_replication_source_slot_lock'), \
+             patch('src.main.helpers.await_for_value', return_value=None):
+            result = inst._check_archive_recovery('primary.example.com', limit=10)
+        assert result is None
+
+
+class TestMakeElection:
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        inst.zk = MagicMock()
+        inst.config = MagicMock()
+        inst.config.getint.return_value = 10
+        inst._replication_manager = MagicMock()
+        return inst
+
+    def test_returns_false_without_sys_exit_on_election_error(self):
+        from src.failover_election import ElectionError
+        inst = self._make()
+        inst.db.get_wal_receive_lsn.return_value = 0
+        inst.zk.get_alive_hosts.return_value = []
+        with patch('src.main.helpers.make_current_replics_quorum', return_value=[]), \
+             patch('src.main.FailoverElection') as MockElection:
+            MockElection.return_value.make_election.side_effect = ElectionError("election failed")
+            with patch('sys.exit') as mock_exit:
+                result = inst._make_election(replica_infos=[], allow_data_loss=False)
+        assert result is False
+        mock_exit.assert_not_called()
+
+
+class TestDoPrimarySwitchoverCosmetic:
+    """_do_primary_switchover continues when cosmetic operations raise PostgresConnectionError."""
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        inst.zk = MagicMock()
+        inst.config = MagicMock()
+        inst.config.getfloat.return_value = 0.0
+        inst.config.getint.return_value = 0
+        inst.config.getboolean.return_value = False
+        inst._replication_manager = MagicMock()
+        return inst
+
+    def test_switchover_continues_when_checkpoint_raises(self):
+        """checkpoint() raises PostgresConnectionError → switchover continues, pgpooler('stop') is called."""
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+
+        inst._replication_manager.change_replication_to_sync_host.return_value = True
+        inst.zk.write_switchover_candidate.return_value = True
+        inst.zk.write_switchover_side_replicas.return_value = True
+        inst.zk.get_switchover_state.return_value = 'candidate_found'
+        inst.db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        inst.db.checkpoint.side_effect = PostgresConnectionError("db down")
+        # abort early after pgpooler to avoid mocking further steps
+        inst._debug_failure = MagicMock(return_value=True)
+
+        db_state = {'replics_info': []}
+        zk_state = {}
+
+        with patch('src.main.log_event'), \
+             patch('src.main.helpers.await_for', return_value=True), \
+             patch.object(inst, '_start_timing'), \
+             patch.object(inst, '_get_streaming_replicas', return_value=[]), \
+             patch.object(inst, '_store_replics_info'):
+            inst._do_primary_switchover('replica1.example.com', db_state, zk_state)
+
+        inst.db.pgpooler.assert_called_with('stop')
+
+    def test_switchover_continues_when_replics_info_update_raises(self):
+        """get_replics_info raises in cosmetic block → switchover continues, checkpoint is still attempted."""
+        from src.exceptions import PostgresConnectionError
+        inst = self._make()
+
+        inst._replication_manager.change_replication_to_sync_host.return_value = True
+        inst.zk.write_switchover_candidate.return_value = True
+        inst.zk.write_switchover_side_replicas.return_value = True
+        inst.zk.get_switchover_state.return_value = 'candidate_found'
+        inst.db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        inst.db.checkpoint.return_value = True
+        inst._debug_failure = MagicMock(return_value=True)
+
+        db_state = {'replics_info': []}
+        zk_state = {}
+
+        with patch('src.main.log_event'), \
+             patch('src.main.helpers.await_for', return_value=True), \
+             patch.object(inst, '_start_timing'), \
+             patch.object(inst, '_get_streaming_replicas', return_value=[]), \
+             patch.object(inst, '_store_replics_info'):
+            inst._do_primary_switchover('replica1.example.com', db_state, zk_state)
+
+        inst.db.checkpoint.assert_called_once()
+        inst.db.pgpooler.assert_called_with('stop')
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_postgresql_streaming
+# ---------------------------------------------------------------------------
+
+class TestCheckPostgresqlStreaming:
+    """_check_postgresql_streaming returns None (not raises) when check_walreceiver raises PostgresConnectionError."""
+
+    def _make(self):
+        from src.main import pgconsul as PgConsul
+        with patch('src.main.pgconsul.__init__', return_value=None):
+            inst = PgConsul.__new__(PgConsul)
+        inst.db = MagicMock()
+        inst.zk = MagicMock()
+        inst.config = MagicMock()
+        inst.config.getboolean.return_value = False  # replication_slots_polling=False
+        return inst
+
+    def test_returns_none_when_check_walreceiver_raises_connection_error(self):
+        """If check_walreceiver raises PostgresConnectionError, function returns None instead of propagating."""
+        from src.exceptions import PostgresConnectionError
+
+        inst = self._make()
+
+        # DB is alive and in terminal state
+        inst.db.is_alive_and_in_terminal_state.return_value = (True, True)
+        # Role is replica — passes the role check
+        inst.db.get_role.return_value = 'replica'
+        # check_walreceiver raises connection error
+        inst.db.check_walreceiver.side_effect = PostgresConnectionError("connection lost")
+
+        # Build replica_infos so that _is_caught_up returns True
+        replica_info = {'application_name': 'myhost', 'state': 'streaming'}
+
+        with patch('src.main.helpers.app_name_from_fqdn', return_value='myhost'), \
+             patch('src.main.helpers.get_hostname', return_value='myhost.example.com'), \
+             patch.object(inst, '_acquire_replication_source_slot_lock'), \
+             patch.object(inst, '_get_replics_info_from_zk', return_value=[replica_info]):
+            result = inst._check_postgresql_streaming('primary.example.com')
+
+        assert result is None
+
+    def test_does_not_raise_when_check_walreceiver_raises_connection_error(self):
+        """PostgresConnectionError from check_walreceiver must never propagate out of _check_postgresql_streaming."""
+        from src.exceptions import PostgresConnectionError
+
+        inst = self._make()
+        inst.db.is_alive_and_in_terminal_state.return_value = (True, True)
+        inst.db.get_role.return_value = 'replica'
+        inst.db.check_walreceiver.side_effect = PostgresConnectionError("db gone")
+
+        replica_info = {'application_name': 'myhost', 'state': 'streaming'}
+
+        with patch('src.main.helpers.app_name_from_fqdn', return_value='myhost'), \
+             patch('src.main.helpers.get_hostname', return_value='myhost.example.com'), \
+             patch.object(inst, '_acquire_replication_source_slot_lock'), \
+             patch.object(inst, '_get_replics_info_from_zk', return_value=[replica_info]):
+            # Must not raise
+            try:
+                inst._check_postgresql_streaming('primary.example.com')
+            except PostgresConnectionError:
+                pytest.fail("PostgresConnectionError propagated out of _check_postgresql_streaming")
+
+    def test_returns_true_when_streaming_normally(self):
+        """Sanity check: returns True when _is_caught_up and check_walreceiver both succeed."""
+        inst = self._make()
+        inst.db.is_alive_and_in_terminal_state.return_value = (True, True)
+        inst.db.get_role.return_value = 'replica'
+        inst.db.check_walreceiver.return_value = True
+
+        replica_info = {'application_name': 'myhost', 'state': 'streaming'}
+
+        with patch('src.main.helpers.app_name_from_fqdn', return_value='myhost'), \
+             patch('src.main.helpers.get_hostname', return_value='myhost.example.com'), \
+             patch.object(inst, '_acquire_replication_source_slot_lock'), \
+             patch.object(inst, '_get_replics_info_from_zk', return_value=[replica_info]):
+            result = inst._check_postgresql_streaming('primary.example.com')
+
+        assert result is True

--- a/tests/unit/test_main_switchover.py
+++ b/tests/unit/test_main_switchover.py
@@ -408,7 +408,7 @@ class TestMakeElection:
              patch('src.main.FailoverElection') as MockElection:
             MockElection.return_value.make_election.side_effect = ElectionError("election failed")
             with patch('sys.exit') as mock_exit:
-                result = inst._make_election(replica_infos=[], allow_data_loss=False)
+                result = inst._make_election(replica_infos=[], allow_data_loss=False, wal_lsn=0)
         assert result is False
         mock_exit.assert_not_called()
 
@@ -560,3 +560,4 @@ class TestCheckPostgresqlStreaming:
             result = inst._check_postgresql_streaming('primary.example.com')
 
         assert result is True
+

--- a/tests/unit/test_pg.py
+++ b/tests/unit/test_pg.py
@@ -1,0 +1,621 @@
+# encoding: utf-8
+# noqa: E501
+"""
+Unit tests for src/pg.py.
+
+Uses mocked psycopg2 so no real PostgreSQL instance is needed.
+The conftest.py at this directory level stubs out psycopg2 with real
+exception classes before any import from src occurs.
+"""
+
+import psycopg2
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from src.exceptions import (
+    PostgresException,
+    PostgresConnectionError,
+    PostgresQueryError,
+    pgconsulException,
+)
+from src.pg import Postgres, PostgresConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides) -> PostgresConfig:
+    """Return a minimal PostgresConfig suitable for unit tests."""
+    defaults = dict(
+        conn_string='host=localhost port=5432 dbname=postgres user=postgres',
+        use_lwaldump=False,
+        working_dir='/tmp',
+        recovery_filepath='/tmp/recovery.conf',
+        use_replication_slots=False,
+        standalone_pooler=False,
+        pooler_conn_timeout=1.0,
+        pooler_addr='localhost',
+        pooler_port=6432,
+        postgres_timeout=5.0,
+        iteration_timeout=5.0,
+    )
+    defaults.update(overrides)
+    return PostgresConfig(**defaults)
+
+
+def _make_postgres(conn=None, mock_cmd=None) -> Postgres:
+    """
+    Create a Postgres instance without touching a real DB.
+
+    Both psycopg2.connect and CommandManager are mocked so __init__ succeeds.
+    """
+    if mock_cmd is None:
+        mock_cmd = MagicMock()
+        mock_cmd.list_clusters.return_value = []
+
+    config = _make_config()
+
+    with patch('src.pg.psycopg2.connect') as mock_connect:
+        if conn is not None:
+            mock_connect.return_value = conn
+        else:
+            fake_conn = MagicMock()
+            fake_conn.cursor.return_value = MagicMock()
+            mock_connect.return_value = fake_conn
+
+        with patch.object(Postgres, 'get_role', return_value='primary'), \
+             patch.object(Postgres, '_get_pgdata_path', return_value='/data/pg'):
+            pg = Postgres(config, mock_cmd)
+
+    return pg
+
+
+# ---------------------------------------------------------------------------
+# Tests: exception hierarchy
+# ---------------------------------------------------------------------------
+
+class TestExceptionHierarchy:
+    """PostgresException hierarchy is properly derived from pgconsulException."""
+
+    def test_postgres_exception_is_pgconsul_exception(self):
+        assert issubclass(PostgresException, pgconsulException)
+
+    def test_postgres_connection_error_is_postgres_exception(self):
+        assert issubclass(PostgresConnectionError, PostgresException)
+
+    def test_postgres_query_error_is_postgres_exception(self):
+        assert issubclass(PostgresQueryError, PostgresException)
+
+    def test_postgres_connection_error_is_exception(self):
+        assert issubclass(PostgresConnectionError, Exception)
+
+    def test_raise_and_catch_connection_error(self):
+        with pytest.raises(PostgresConnectionError):
+            raise PostgresConnectionError("connection refused")
+
+    def test_catch_as_postgres_exception(self):
+        with pytest.raises(PostgresException):
+            raise PostgresConnectionError("connection refused")
+
+    def test_catch_as_pgconsul_exception(self):
+        with pytest.raises(pgconsulException):
+            raise PostgresConnectionError("connection refused")
+
+    def test_connection_error_preserves_cause(self):
+        cause = psycopg2.OperationalError("FATAL: connection refused")
+        try:
+            raise PostgresConnectionError(str(cause)) from cause
+        except PostgresConnectionError as exc:
+            assert exc.__cause__ is cause
+
+
+# ---------------------------------------------------------------------------
+# Tests: _exec_query translates psycopg2.OperationalError
+# ---------------------------------------------------------------------------
+
+class TestExecQueryTranslation:
+    """_exec_query must translate psycopg2.OperationalError → PostgresConnectionError."""
+
+    def _make_pg_with_failing_execute(self, exc):
+        """
+        Return a Postgres instance where:
+          - _create_cursor health-check (SELECT 1;) succeeds,
+          - the actual query execute() raises *exc*.
+        """
+        pg = _make_postgres()
+
+        # _create_cursor calls cursor.execute('SELECT 1;') as a health-check,
+        # then _exec_query calls cursor.execute(real_query, {}).
+        # We distinguish them by call count.
+        call_count = {'n': 0}
+
+        def execute_side_effect(query, *args):
+            call_count['n'] += 1
+            if call_count['n'] > 1:
+                # Second call is the real query
+                raise exc
+
+        cur = MagicMock()
+        cur.execute.side_effect = execute_side_effect
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value = cur
+        pg.conn_local = fake_conn
+        return pg
+
+    def test_operational_error_raises_postgres_connection_error(self):
+        """psycopg2.OperationalError during execute → PostgresConnectionError."""
+        pg = self._make_pg_with_failing_execute(
+            psycopg2.OperationalError("server closed the connection")
+        )
+        with pytest.raises(PostgresConnectionError):
+            pg._exec_query("SELECT something")
+
+    def test_operational_error_cause_preserved(self):
+        """The original psycopg2.OperationalError is chained as __cause__."""
+        original = psycopg2.OperationalError("broken pipe")
+        pg = self._make_pg_with_failing_execute(original)
+
+        with pytest.raises(PostgresConnectionError) as exc_info:
+            pg._exec_query("SELECT something")
+        assert exc_info.value.__cause__ is original
+
+    def test_other_exception_not_translated(self):
+        """Non-OperationalError exceptions are NOT translated."""
+        pg = self._make_pg_with_failing_execute(ValueError("unexpected"))
+        with pytest.raises(ValueError):
+            pg._exec_query("SELECT something")
+
+    def test_connection_closed_after_operational_error(self):
+        """After psycopg2.OperationalError, self.close() is called."""
+        pg = self._make_pg_with_failing_execute(
+            psycopg2.OperationalError("broken")
+        )
+        with patch.object(pg, 'close') as mock_close:
+            with pytest.raises(PostgresConnectionError):
+                pg._exec_query("SELECT something")
+            mock_close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: PR 1 — low-risk functions (no @return_none_on_error decorator)
+# ---------------------------------------------------------------------------
+
+class TestGetWalReceiverInfo:
+    """_get_wal_receiver_info raises PostgresConnectionError on DB error."""
+
+    def test_returns_first_row_on_success(self):
+        """Returns first row dict when pg_stat_wal_receiver has data."""
+        pg = _make_postgres()
+        row = {'pid': 1234, 'status': 'streaming', 'slot_name': None,
+               'last_msg_receipt_time_msec': 0, 'conninfo': 'host=primary'}
+        with patch.object(pg, '_get', return_value=[row]):
+            result = pg._get_wal_receiver_info()
+        assert result == row
+
+    def test_returns_none_when_empty(self):
+        """Returns None (no walreceiver running) when query returns empty list."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', return_value=[]):
+            result = pg._get_wal_receiver_info()
+        assert result is None
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no safe default returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg._get_wal_receiver_info()
+
+
+class TestGetSessionsRatio:
+    """get_sessions_ratio raises PostgresConnectionError on DB error."""
+
+    def test_returns_ratio(self):
+        """Returns float ratio of active / max_connections."""
+        pg = _make_postgres()
+        # First call: active sessions count; second call: max_connections
+        active_cur = MagicMock()
+        active_cur.fetchone.return_value = (5,)
+        max_cur = MagicMock()
+        max_cur.fetchone.return_value = ('100',)
+
+        with patch.object(pg, '_exec_query', side_effect=[active_cur, max_cur]):
+            result = pg.get_sessions_ratio()
+        assert result == pytest.approx(5.0)
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no 0.0 safe default returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_sessions_ratio()
+
+
+class TestGetWalReceiveLsn:
+    """get_wal_receive_lsn raises PostgresConnectionError on DB error."""
+
+    def test_returns_lsn_value(self):
+        """Returns LSN integer from pg_last_wal_receive_lsn diff."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = (12345678,)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg.get_wal_receive_lsn()
+        assert result == 12345678
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no None returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_wal_receive_lsn()
+
+    def test_raises_via_lwaldump_on_connection_error(self):
+        """When use_lwaldump=True, PostgresConnectionError from lwaldump propagates."""
+        config = _make_config(use_lwaldump=True)
+        mock_cmd = MagicMock()
+        mock_cmd.list_clusters.return_value = []
+        with patch('src.pg.psycopg2.connect') as mock_connect:
+            fake_conn = MagicMock()
+            fake_conn.cursor.return_value = MagicMock()
+            mock_connect.return_value = fake_conn
+            with patch.object(Postgres, 'get_role', return_value='replica'), \
+                 patch.object(Postgres, '_get_pgdata_path', return_value='/data/pg'):
+                pg = Postgres(config, mock_cmd)
+
+        with patch.object(pg, 'lwaldump', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_wal_receive_lsn()
+
+
+# ---------------------------------------------------------------------------
+# Tests: PR 2 — get_replication_slots + lwaldump
+# ---------------------------------------------------------------------------
+
+class TestGetReplicationSlots:
+    """get_replication_slots raises PostgresConnectionError on DB error."""
+
+    def test_returns_slot_list(self):
+        """Returns list of slot names on success."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', return_value=[{'slot_name': 'slot_a'}, {'slot_name': 'slot_b'}]):
+            result = pg.get_replication_slots()
+        assert result == ['slot_a', 'slot_b']
+
+    def test_returns_empty_list_when_no_slots(self):
+        """Returns empty list when pg_replication_slots has no rows."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', return_value=[]):
+            result = pg.get_replication_slots()
+        assert result == []
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no None returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_replication_slots()
+
+    def test_other_exception_propagates(self):
+        """Non-connection errors also propagate to the caller."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', side_effect=RuntimeError("unexpected")):
+            with pytest.raises(RuntimeError):
+                pg.get_replication_slots()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_replics_info raises PostgresConnectionError on DB error
+# ---------------------------------------------------------------------------
+
+class TestGetReplicsInfo:
+    """get_replics_info raises PostgresConnectionError on DB error."""
+
+    def test_returns_replica_list(self):
+        """Returns list of replica dicts on success."""
+        pg = _make_postgres()
+        row = {'pid': 1, 'application_name': 'replica1', 'state': 'streaming',
+               'sync_state': 'async'}
+        with patch.object(pg, '_get', return_value=[row]):
+            result = pg.get_replics_info('primary')
+        assert result == [row]
+
+    def test_returns_empty_list_when_no_replicas(self):
+        """Returns empty list when no replicas connected."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', return_value=[]):
+            result = pg.get_replics_info('primary')
+        assert result == []
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no [] safe default returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_get', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_replics_info('primary')
+
+
+# ---------------------------------------------------------------------------
+# Tests: PR 4 — get_replication_state (safe default on DB error)
+# ---------------------------------------------------------------------------
+
+class TestGetReplicationState:
+    """get_replication_state raises PostgresConnectionError on DB error."""
+
+    def test_returns_async_when_ssn_empty(self):
+        """Returns ('async', None) when synchronous_standby_names is empty."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = ('',)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg.get_replication_state()
+        assert result == ('async', None)
+
+    def test_returns_sync_with_value(self):
+        """Returns ('sync', value) when synchronous_standby_names is set."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = ('ANY 1 (replica1)',)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg.get_replication_state()
+        assert result == ('sync', 'ANY 1 (replica1)')
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no ('async', None) safe default."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_replication_state()
+
+
+class TestLwaldump:
+    """lwaldump raises PostgresConnectionError on DB error (no decorator)."""
+
+    def test_returns_lsn_integer(self):
+        """Returns integer LSN value on success."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = (9876543,)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg.lwaldump()
+        assert result == 9876543
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates when DB is unavailable."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.lwaldump()
+
+
+# ---------------------------------------------------------------------------
+# Tests: PR 3 — _get_pgdata_path (no @return_none_on_error)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Tests: PR 5 — get_replay_diff + is_replaying_wal
+# ---------------------------------------------------------------------------
+
+class TestGetReplayDiff:
+    """get_replay_diff raises PostgresConnectionError on DB error."""
+
+    def test_returns_diff_value(self):
+        """Returns integer LSN diff on success."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = (42,)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg.get_replay_diff()
+        assert result == 42
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates — no None returned."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.get_replay_diff()
+
+
+class TestIsReplayingWal:
+    """is_replaying_wal raises PostgresConnectionError on DB error."""
+
+    def test_returns_true_when_replaying(self):
+        """Returns True when replay LSN increases between checks."""
+        pg = _make_postgres()
+        with patch.object(pg, 'get_replay_diff', side_effect=[100, 200]), \
+             patch('src.pg.time.sleep'):
+            result = pg.is_replaying_wal(1)
+        assert result is True
+
+    def test_returns_false_when_not_replaying(self):
+        """Returns False when replay LSN does not change."""
+        pg = _make_postgres()
+        with patch.object(pg, 'get_replay_diff', side_effect=[100, 100]), \
+             patch('src.pg.time.sleep'):
+            result = pg.is_replaying_wal(1)
+        assert result is False
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates from get_replay_diff."""
+        pg = _make_postgres()
+        with patch.object(pg, 'get_replay_diff', side_effect=PostgresConnectionError("db down")), \
+             patch('src.pg.time.sleep'):
+            with pytest.raises(PostgresConnectionError):
+                pg.is_replaying_wal(1)
+
+
+class TestGetPgdataPath:
+    """_get_pgdata_path raises PostgresConnectionError instead of returning None."""
+
+    def test_returns_path_on_success(self):
+        """Returns data directory path string on success."""
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchone.return_value = ('/var/lib/postgresql/data',)
+        with patch.object(pg, '_exec_query', return_value=cur):
+            result = pg._get_pgdata_path()
+        assert result == '/var/lib/postgresql/data'
+
+    def test_raises_on_connection_error(self):
+        """PostgresConnectionError propagates when DB is unavailable."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg._get_pgdata_path()
+
+    def test_other_exception_propagates(self):
+        """Non-connection exceptions also propagate (no suppression)."""
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=RuntimeError("unexpected")):
+            with pytest.raises(RuntimeError):
+                pg._get_pgdata_path()
+
+
+class TestReconnect:
+    """reconnect() handles PostgresConnectionError from _get_pgdata_path."""
+
+    def test_reconnect_success(self):
+        """On success, conn_local is set and pgdata is populated."""
+        pg = _make_postgres()
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value = MagicMock()
+
+        with patch('src.pg.psycopg2.connect', return_value=fake_conn), \
+             patch.object(pg, 'get_role', return_value='primary'), \
+             patch.object(pg, '_get_pgdata_path', return_value='/data/pg'):
+            pg.reconnect()
+
+        assert pg.conn_local is fake_conn
+        assert pg.pgdata == '/data/pg'
+        assert pg.terminal_state is True
+
+    def test_reconnect_psycopg2_operational_error(self):
+        """psycopg2.OperationalError during connect → conn_local is None."""
+        pg = _make_postgres()
+        with patch('src.pg.psycopg2.connect', side_effect=psycopg2.OperationalError("refused")):
+            pg.reconnect()
+
+        assert pg.conn_local is None
+
+    def test_reconnect_postgres_connection_error_from_pgdata(self):
+        """PostgresConnectionError from _get_pgdata_path → conn_local is set to None."""
+        pg = _make_postgres()
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value = MagicMock()
+
+        with patch('src.pg.psycopg2.connect', return_value=fake_conn), \
+             patch.object(pg, 'get_role', return_value='primary'), \
+             patch.object(pg, '_get_pgdata_path', side_effect=PostgresConnectionError("show data_directory failed")):
+            pg.reconnect()
+
+        assert pg.conn_local is None
+
+    def test_reconnect_postgres_connection_error_does_not_raise(self):
+        """PostgresConnectionError from _get_pgdata_path is caught, reconnect() returns normally."""
+        pg = _make_postgres()
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value = MagicMock()
+
+        with patch('src.pg.psycopg2.connect', return_value=fake_conn), \
+             patch.object(pg, 'get_role', return_value='primary'), \
+             patch.object(pg, '_get_pgdata_path', side_effect=PostgresConnectionError("show data_directory failed")):
+            # Should not raise
+            pg.reconnect()
+
+
+class TestGetState:
+
+    def test_alive_false_when_db_not_running(self):
+        pg = _make_postgres()
+        with patch.object(pg, 'is_alive_and_in_terminal_state', return_value=(False, True)):
+            result = pg.get_state()
+        assert result['alive'] is False
+
+    def test_get_state_does_not_raise_on_connection_error_in_wal_receiver(self):
+        # get_state() swallows exceptions via except Exception — must not raise
+        pg = _make_postgres()
+        with patch.object(pg, 'is_alive_and_in_terminal_state', return_value=(True, True)), \
+             patch.object(pg, 'get_role', return_value='replica'), \
+             patch.object(pg, '_get_pgdata_path', return_value='/data'), \
+             patch.object(pg, 'pgpooler', return_value=(True, True)), \
+             patch.object(pg, 'get_timeline', return_value=1), \
+             patch.object(pg, '_get_wal_receiver_info', side_effect=PostgresConnectionError("db down")):
+            result = pg.get_state()  # must not raise
+        assert result['alive'] is False
+
+    def test_get_state_does_not_raise_on_connection_error_in_replics_info(self):
+        pg = _make_postgres()
+        with patch.object(pg, 'is_alive_and_in_terminal_state', return_value=(True, True)), \
+             patch.object(pg, 'get_role', return_value='primary'), \
+             patch.object(pg, '_get_pgdata_path', return_value='/data'), \
+             patch.object(pg, 'pgpooler', return_value=(True, True)), \
+             patch.object(pg, 'get_timeline', return_value=1), \
+             patch.object(pg, '_get_wal_receiver_info', return_value=None), \
+             patch.object(pg, 'get_replics_info', side_effect=PostgresConnectionError("db down")):
+            result = pg.get_state()  # must not raise
+        assert result['alive'] is False
+
+
+class TestCheckpoint:
+
+    def test_checkpoint_succeeds(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', return_value=True):
+            assert pg.checkpoint() is True
+
+    def test_checkpoint_raises_on_connection_error(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.checkpoint()
+
+    def test_checkpoint_with_custom_query(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', return_value=True) as mock_exec:
+            pg.checkpoint(query='CHECKPOINT;')
+        mock_exec.assert_called_once_with('CHECKPOINT;')
+
+
+class TestCheckWalreceiver:
+
+    def test_returns_true_when_streaming(self):
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchall.return_value = [(1234,)]
+        with patch.object(pg, '_exec_query', return_value=cur):
+            assert pg.check_walreceiver() is True
+
+    def test_returns_false_when_not_streaming(self):
+        pg = _make_postgres()
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        with patch.object(pg, '_exec_query', return_value=cur):
+            assert pg.check_walreceiver() is False
+
+    def test_raises_on_connection_error(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_query', side_effect=PostgresConnectionError("db down")):
+            with pytest.raises(PostgresConnectionError):
+                pg.check_walreceiver()
+
+
+class TestTerminateBackend:
+
+    def test_terminate_backend_succeeds(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', return_value=True):
+            assert pg.terminate_backend(1234) is None
+
+    def test_terminate_backend_catches_connection_error(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', side_effect=PostgresConnectionError("db down")):
+            pg.terminate_backend(1234)  # must not raise
+
+    def test_terminate_backend_logs_warning_on_connection_error(self):
+        pg = _make_postgres()
+        with patch.object(pg, '_exec_without_result', side_effect=PostgresConnectionError("db down")), \
+             patch('src.pg.logging.warning') as mock_warning:
+            pg.terminate_backend(1234)
+        mock_warning.assert_called_once()
+        assert '1234' in str(mock_warning.call_args[0])

--- a/tests/unit/test_pg.py
+++ b/tests/unit/test_pg.py
@@ -252,7 +252,7 @@ class TestGetWalReceiveLsn:
                 pg.get_wal_receive_lsn()
 
     def test_raises_via_lwaldump_on_connection_error(self):
-        """When use_lwaldump=True, PostgresConnectionError from lwaldump propagates."""
+        """When use_lwaldump=True and walreceiver active, PostgresConnectionError from lwaldump propagates."""
         config = _make_config(use_lwaldump=True)
         mock_cmd = MagicMock()
         mock_cmd.list_clusters.return_value = []
@@ -264,7 +264,9 @@ class TestGetWalReceiveLsn:
                  patch.object(Postgres, '_get_pgdata_path', return_value='/data/pg'):
                 pg = Postgres(config, mock_cmd)
 
-        with patch.object(pg, 'lwaldump', side_effect=PostgresConnectionError("db down")):
+        # walreceiver is active → lwaldump is called → raises
+        with patch.object(pg, 'is_wal_receiver_disabled', return_value=False), \
+             patch.object(pg, 'lwaldump', side_effect=PostgresConnectionError("db down")):
             with pytest.raises(PostgresConnectionError):
                 pg.get_wal_receive_lsn()
 

--- a/tests/unit/test_replication_manager_ssn.py
+++ b/tests/unit/test_replication_manager_ssn.py
@@ -7,7 +7,7 @@ Here we test only the ReplicationManager-level behaviour of set_ssn_before_promo
 """
 
 import importlib
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from configparser import RawConfigParser
 
 # Bootstrap (sys.path, sys.modules stubs) is handled by conftest.py
@@ -128,3 +128,28 @@ class TestSetSsnBeforePromote:
             'Setting SSN before promote: ANY 2(h1,h2,h3).',
             'Set SSN before promote.',
         )
+
+
+class TestShouldClose:
+
+    def _make_manager(self):
+        from src.replication_manager import ReplicationManager
+        manager, db, zk, _ = _make_manager()
+        manager._zk_fail_timestamp = None
+        return manager, db
+
+    def test_returns_true_on_connection_error(self):
+        from src.exceptions import PostgresConnectionError
+        manager, db = self._make_manager()
+        db.get_replics_info.side_effect = PostgresConnectionError("db down")
+        with patch('src.replication_manager.time.time', return_value=1000.0):
+            result = manager.should_close()
+        assert result is True
+
+    def test_returns_false_for_async_replication(self):
+        manager, db = self._make_manager()
+        db.get_replics_info.return_value = []
+        db.get_replication_state.return_value = ('async', None)
+        with patch('src.replication_manager.time.time', return_value=1000.0):
+            result = manager.should_close()
+        assert result is False

--- a/tests/unit/test_slot_manager.py
+++ b/tests/unit/test_slot_manager.py
@@ -1,0 +1,242 @@
+# encoding: utf-8
+"""
+Unit tests for src/slot_manager.py — ReplicationSlotManager.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.exceptions import PostgresConnectionError
+from src.slot_manager import ReplicationSlotManager, ReplicationSlotManagerConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(
+    replication_slots_polling=True, use_replication_slots=True, drop_slot_countdown=5
+):
+    return ReplicationSlotManagerConfig(
+        replication_slots_polling=replication_slots_polling,
+        use_replication_slots=use_replication_slots,
+        drop_slot_countdown=drop_slot_countdown,
+    )
+
+
+def _make_manager(config=None, db=None, zk=None):
+    if config is None:
+        config = _make_config()
+    if db is None:
+        db = MagicMock()
+    if zk is None:
+        zk = MagicMock()
+    return ReplicationSlotManager(db, zk, config)
+
+
+# ---------------------------------------------------------------------------
+# Tests: handle_slots
+# ---------------------------------------------------------------------------
+
+class TestHandleSlots:
+    """handle_slots orchestrates slot creation and dropping."""
+
+    def test_skips_when_polling_disabled(self):
+        """Does nothing when replication_slots_polling is off."""
+        config = _make_config(replication_slots_polling=False)
+        manager = _make_manager(config=config)
+        manager.handle_slots()
+        manager._zk.get_lock_contenders.assert_not_called()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_skips_when_lock_contenders_fail(self, _mock_hostname):
+        """Returns early when ZK get_lock_contenders raises."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.side_effect = Exception('zk error')
+        manager.handle_slots()
+        manager._zk.get_members.assert_not_called()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_skips_when_no_members(self, _mock_hostname):
+        """Returns early when ZK members list is empty."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = ['host2']
+        manager._zk.get_members.return_value = []
+        manager.handle_slots()
+        manager._db.get_replication_slots.assert_not_called()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_calls_sync_slots_with_correct_names(self, _mock_hostname):
+        """Creates slots for lock holders, drops none."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = ['host2', 'host3']
+        manager._zk.get_members.return_value = ['host1', 'host2', 'host3']
+        manager._db.get_replication_slots.return_value = []
+
+        manager.handle_slots()
+
+        created = [c.args[0] for c in manager._db._create_replication_slot.call_args_list]
+        assert 'host2' in created
+        assert 'host3' in created
+        # host1 is the current host, should not be in drop list
+        manager._db._drop_replication_slot.assert_not_called()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_excludes_self_from_drop_list(self, _mock_hostname):
+        """Current host is excluded from the drop list."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = []
+        manager._zk.get_members.return_value = ['host1', 'host2']
+        manager._db.get_replication_slots.return_value = ['host1', 'host2']
+        # Pre-set countdown so host2 is expired (will go to -1)
+        manager._drop_countdown = {'host1': 0, 'host2': 0}
+
+        manager.handle_slots()
+
+        manager._db._create_replication_slot.assert_not_called()
+        dropped = [c.args[0] for c in manager._db._drop_replication_slot.call_args_list]
+        assert 'host1' not in dropped  # self excluded
+        assert 'host2' in dropped
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_catches_postgres_connection_error(self, _mock_hostname):
+        """Catches PostgresConnectionError from get_replication_slots and logs warning."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = ['host2']
+        manager._zk.get_members.return_value = ['host1', 'host2']
+        manager._db.get_replication_slots.side_effect = PostgresConnectionError('db down')
+
+        # Should not raise
+        manager.handle_slots()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_logs_warning_on_create_failure(self, _mock_hostname):
+        """Logs warning when slot creation raises PostgresConnectionError."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = ['host2']
+        manager._zk.get_members.return_value = ['host1', 'host2']
+        manager._db.get_replication_slots.return_value = []
+        manager._db._create_replication_slot.side_effect = PostgresConnectionError('db error')
+
+        manager.handle_slots()
+
+    @patch('src.slot_manager.helpers.get_hostname', return_value='host1')
+    def test_drop_failure_sets_drop_ok_false(self, _mock_hostname):
+        """drop_ok=False when _drop_replication_slot raises PostgresConnectionError."""
+        manager = _make_manager()
+        manager._zk.get_lock_contenders.return_value = []
+        manager._zk.get_members.return_value = ['host1', 'host2']
+        manager._db.get_replication_slots.return_value = ['host2']
+        manager._drop_countdown = {'host1': 0, 'host2': 0}
+        manager._db._drop_replication_slot.side_effect = PostgresConnectionError('db error')
+
+        manager.handle_slots()
+
+        manager._db._drop_replication_slot.assert_called_once_with('host2')
+
+
+# ---------------------------------------------------------------------------
+# Tests: _compute_non_holders
+# ---------------------------------------------------------------------------
+
+class TestComputeNonHolders:
+    """_compute_non_holders tracks countdown and returns expired hosts."""
+
+    def test_holder_resets_countdown(self):
+        """Host holding the lock has countdown reset to default."""
+        manager = _make_manager()
+        manager._drop_countdown['host2'] = 0  # was about to expire
+        result = manager._compute_non_holders(['host2'], {'host2'})
+
+        assert result == []
+        assert manager._drop_countdown['host2'] == 5
+
+    def test_non_holder_decrements_countdown(self):
+        """Host not holding the lock has countdown decremented."""
+        manager = _make_manager()
+        manager._drop_countdown['host2'] = 3
+        result = manager._compute_non_holders(['host2'], set())
+
+        assert result == []
+        assert manager._drop_countdown['host2'] == 2
+
+    def test_non_holder_added_when_countdown_expired(self):
+        """Host with countdown below zero is added to non_holders."""
+        manager = _make_manager()
+        manager._drop_countdown['host2'] = 0
+        result = manager._compute_non_holders(['host2'], set())
+
+        assert result == ['host2']
+        assert manager._drop_countdown['host2'] == -1
+
+    def test_new_host_gets_default_countdown(self):
+        """Host not in countdown dict gets default value."""
+        manager = _make_manager()
+        result = manager._compute_non_holders(['host2'], set())
+
+        assert result == []
+        assert manager._drop_countdown['host2'] == 4  # 5 - 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_slots_for_hosts
+# ---------------------------------------------------------------------------
+
+class TestCreateSlotsForHosts:
+    """create_slots_for_hosts creates missing slots via db primitives."""
+
+    def test_skips_when_use_replication_slots_disabled(self):
+        """Returns True when use_replication_slots is off."""
+        config = _make_config(use_replication_slots=False)
+        manager = _make_manager(config=config)
+        assert manager.create_slots_for_hosts(['host2']) is True
+        manager._db.get_replication_slots.assert_not_called()
+
+    def test_skips_when_hosts_empty(self):
+        """Returns True when hosts list is empty."""
+        manager = _make_manager()
+        assert manager.create_slots_for_hosts([]) is True
+        manager._db.get_replication_slots.assert_not_called()
+
+    def test_returns_true_on_success(self):
+        """Returns True when all slots are created."""
+        manager = _make_manager()
+        manager._db.get_replication_slots.return_value = []
+        manager._db._create_replication_slot.return_value = True
+        assert manager.create_slots_for_hosts(['host2', 'host3']) is True
+        assert manager._db._create_replication_slot.call_count == 2
+
+    def test_returns_false_on_failure(self):
+        """Returns False when slot creation raises PostgresConnectionError."""
+        manager = _make_manager()
+        manager._db.get_replication_slots.return_value = []
+        manager._db._create_replication_slot.side_effect = PostgresConnectionError('db error')
+        assert manager.create_slots_for_hosts(['host2']) is False
+
+    def test_propagates_connection_error_from_get_slots(self):
+        """PostgresConnectionError from get_replication_slots propagates to caller."""
+        manager = _make_manager()
+        manager._db.get_replication_slots.side_effect = PostgresConnectionError('db error')
+        with pytest.raises(PostgresConnectionError):
+            manager.create_slots_for_hosts(['host2'])
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset_on_promote
+# ---------------------------------------------------------------------------
+
+class TestResetOnPromote:
+    """reset_on_promote clears the countdown dict."""
+
+    def test_clears_countdown(self):
+        """Empties the _drop_countdown dict."""
+        manager = _make_manager()
+        manager._drop_countdown = {'host2': 3, 'host3': 1}
+        manager.reset_on_promote()
+        assert manager._drop_countdown == {}
+
+    def test_clears_empty_countdown(self):
+        """Works correctly when countdown is already empty."""
+        manager = _make_manager()
+        manager.reset_on_promote()
+        assert manager._drop_countdown == {}


### PR DESCRIPTION
Wrap WAL replay resume logic in try/except to prevent unhandled exceptions from crashing the iteration. On failure, a warning is logged with traceback and the operation is retried on next cycle.

Fix race condition in cascade.feature