### PR TITLE
MDB-46149: prevent restart of overloaded but alive postgres

### DIFF
--- a/.github/workflows/docker-unit.yml
+++ b/.github/workflows/docker-unit.yml
@@ -1,4 +1,4 @@
-name: Mypy tests
+name: Unit tests
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: mypy
+    name: unit tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
@@ -16,8 +16,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - name: Install tox
-        run: pip install tox
+      - name: Install dependencies
+        run: |
+          pip install pytest pytest-cov
+          pip install -r requirements.txt
 
-      - name: Test
-        run: make mypy
+      - name: Run unit tests
+        run: make unit_test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,14 +14,11 @@ jobs:
   mypy:
     uses: ./.github/workflows/docker-mypy.yml
 
+  unit:
+    uses: ./.github/workflows/docker-unit.yml
+
   behave:
     name: behave
-    needs: [mypy]
+    needs: [mypy, unit]
     if: success()
     uses: ./.github/workflows/docker-behave.yml
-
-  jepsen:
-    name: jepsen
-    needs: [mypy]
-    if: success()
-    uses: ./.github/workflows/docker-jepsen.yml

--- a/Makefile
+++ b/Makefile
@@ -115,3 +115,9 @@ check-world: clean build check_test jepsen_test
 
 mypy:
 	tox -e mypy
+
+unit_test:
+	pytest tests/unit/test_*.py -v
+
+unit_test_coverage:
+	pytest tests/unit/test_*.py --cov=src --cov-report=html --cov-report=term

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -74,13 +74,9 @@ pooler_conn_timeout = 1
 # Maximum number of log records in queue before dropping new ones
 async_log_queue_size = 5000
 
-# Number of consecutive connection timeouts to tolerate before forcing a PostgreSQL restart.
-# When pgconsul cannot connect to the local PostgreSQL (e.g. due to overload), it uses
-# exponential backoff for connect_timeout (1→2→4→8→10 seconds). If the process is still
-# running (systemctl reports it active), pgconsul skips the restart until this threshold is reached.
-# After exceeding the threshold, a restart is forced to recover from a potential hang.
-# Set to 1 to restore the old behavior (restart on the first timeout).
-max_conn_timeouts_before_restart = 5
+# Seconds to wait after first connection failure before acting on a running-but-unresponsive
+# PostgreSQL process. Set to 0 to act immediately.
+pg_conn_failure_grace_period = 30
 
 [primary]
 # Whether to change the replication type to synchronous (or asynchronous)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -76,7 +76,7 @@ async_log_queue_size = 5000
 
 # Seconds to wait after first connection failure before acting on a running-but-unresponsive
 # PostgreSQL process. Set to 0 to act immediately.
-pg_conn_failure_grace_period = 30
+pg_conn_failure_grace_period = 0
 
 [primary]
 # Whether to change the replication type to synchronous (or asynchronous)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -74,6 +74,14 @@ pooler_conn_timeout = 1
 # Maximum number of log records in queue before dropping new ones
 async_log_queue_size = 5000
 
+# Number of consecutive connection timeouts to tolerate before forcing a PostgreSQL restart.
+# When pgconsul cannot connect to the local PostgreSQL (e.g. due to overload), it uses
+# exponential backoff for connect_timeout (1→2→4→8→10 seconds). If the process is still
+# running (systemctl reports it active), pgconsul skips the restart until this threshold is reached.
+# After exceeding the threshold, a restart is forced to recover from a potential hang.
+# Set to 1 to restore the old behavior (restart on the first timeout).
+max_conn_timeouts_before_restart = 5
+
 [primary]
 # Whether to change the replication type to synchronous (or asynchronous)
 # Only done if there is a lock in ZK.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,7 +84,7 @@ def read_config(filename=None, options=None):
             'release_lock_after_acquire_failed': 'yes',
             'max_delay_on_zk_reinit': 60,
             'async_log_queue_size': 5000,
-            'pg_conn_failure_grace_period': 30,
+            'pg_conn_failure_grace_period': 0,
         },
         'primary': {
             'change_replication_type': 'yes',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,7 +84,7 @@ def read_config(filename=None, options=None):
             'release_lock_after_acquire_failed': 'yes',
             'max_delay_on_zk_reinit': 60,
             'async_log_queue_size': 5000,
-            'max_conn_timeouts_before_restart': 5,
+            'pg_conn_failure_grace_period': 30,
         },
         'primary': {
             'change_replication_type': 'yes',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,6 +84,7 @@ def read_config(filename=None, options=None):
             'release_lock_after_acquire_failed': 'yes',
             'max_delay_on_zk_reinit': 60,
             'async_log_queue_size': 5000,
+            'max_conn_timeouts_before_restart': 5,
         },
         'primary': {
             'change_replication_type': 'yes',

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -50,3 +50,16 @@ class ResetException(pgconsulException):
     """
 
     pass
+
+
+class PGConnectionTimeout(pgconsulException):
+    """
+    Postgres connection attempt timed out.
+    Raised by reconnect() to signal callers that the connection failed due to timeout.
+    The restart policy (how many timeouts to tolerate before forcing a restart) is
+    intentionally kept outside Postgres class — in PgConsul (main.py).
+    """
+
+    def __init__(self, timeout_count: int):
+        super().__init__(f'PostgreSQL connection timed out (attempt {timeout_count})')
+        self.timeout_count = timeout_count

--- a/src/main.py
+++ b/src/main.py
@@ -60,8 +60,9 @@ class pgconsul(object):
         self._debug_counters: dict[str, int] = {}
         self.last_zk_host_stat_write: float = 0
         self._replication_manager = self._get_repllication_manager()
-        # Number of consecutive iterations where Postgres connection timed out.
-        # Used to decide when to force a restart (see run_iteration).
+        # Restart threshold counter: consecutive iterations where Postgres
+        # connection timed out. Used to decide when to force a restart.
+        # Independent from _conn_timeout_count in pg.py (which drives backoff).
         self._pg_timeout_count: int = 0
         self._max_pg_timeouts: int = self.config.getint('global', 'max_conn_timeouts_before_restart')
         if self._max_pg_timeouts < 1:
@@ -380,6 +381,9 @@ class pgconsul(object):
             self._pg_timeout_count += 1
             pg_status = self.db.get_postgresql_status()
             role = None
+            # True: skip the "waiting for startup/shutdown" branch in dead_iter().
+            # Below threshold dead_iter() returns early; at threshold we want to
+            # proceed to restart without waiting.
             terminal_state = True
             db_state = {
                 'alive': False,

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ import psycopg2
 
 from configparser import RawConfigParser
 
-from . import helpers, sdnotify
+from . import exceptions, helpers, sdnotify
 from .command_manager import CommandManager, Commands
 from .failover_election import ElectionError, FailoverElection
 from .helpers import IterationTimer, get_hostname, register_sigterm_handler, should_run
@@ -60,6 +60,10 @@ class pgconsul(object):
         self._debug_counters: dict[str, int] = {}
         self.last_zk_host_stat_write: float = 0
         self._replication_manager = self._get_repllication_manager()
+        # Number of consecutive iterations where Postgres connection timed out.
+        # Used to decide when to force a restart (see run_iteration).
+        self._pg_timeout_count: int = 0
+        self._max_pg_timeouts: int = self.config.getint('global', 'max_conn_timeouts_before_restart')
 
     def _get_repllication_manager(self) -> ReplicationManager:
         if self.config.getboolean('global', 'quorum_commit'):
@@ -355,13 +359,28 @@ class pgconsul(object):
     def run_iteration(self, my_prio):
         logging.info('Start iteration on host: %s', helpers.get_hostname())
         timer = IterationTimer()
-        _, terminal_state = self.db.is_alive_and_in_terminal_state()
-        if not terminal_state:
-            logging.debug('Database is starting up or shutting down')
-        role = self.db.get_role()
-        logging.info('Role: %s', str(role))
 
-        db_state = self.db.get_state()
+        try:
+            _, terminal_state = self.db.is_alive_and_in_terminal_state()
+            if not terminal_state:
+                logging.debug('Database is starting up or shutting down')
+            role = self.db.get_role()
+            logging.info('Role: %s', str(role))
+            db_state = self.db.get_state()
+            # Successful DB interaction — reset the timeout counter.
+            self._pg_timeout_count = 0
+        except exceptions.PGConnectionTimeout:
+            self._pg_timeout_count += 1
+            pg_status = self.db.get_postgresql_status()
+            role = None
+            terminal_state = True
+            db_state = {
+                'alive': False,
+                'running': pg_status == 0,
+                'prev_state': None,
+                'connection_timeout': True,
+            }
+
         self.notifier.notify()
 
         db_state_for_debug = db_state.copy()
@@ -402,6 +421,9 @@ class pgconsul(object):
         stream_from = self.config.get('global', 'stream_from')
         if role is None:
             self.dead_iter(db_state, zk_state, is_in_terminal_state=terminal_state)
+            self.re_init_zk()
+            self.finish_iteration(timer)
+            return
         elif role == 'primary':
             if self._is_single_node:
                 self.single_node_primary_iter(db_state, zk_state)
@@ -1027,10 +1049,31 @@ class pgconsul(object):
 
     def dead_iter(self, db_state, zk_state, is_in_terminal_state):
         """
-        Iteration if local postgresql is dead
+        Iteration if local postgresql is dead.
+
+        When db_state['connection_timeout'] is True it means PostgreSQL process is
+        reportedly running (systemctl) but pgconsul could not establish a psql
+        connection. In that case we apply a consecutive-timeout threshold before
+        allowing a restart.
         """
         if not zk_state['alive'] or db_state['alive']:
             return None
+
+        if db_state.get('connection_timeout'):
+            if db_state.get('running') and self._pg_timeout_count < self._max_pg_timeouts:
+                logging.warning(
+                    'Connection to postgres failed (timeout), but systemctl reports it is RUNNING. '
+                    'Timeout count: %d/%d. Skipping restart.',
+                    self._pg_timeout_count,
+                    self._max_pg_timeouts,
+                )
+                return None
+            if db_state.get('running'):
+                logging.error(
+                    'Connection to postgres failed %d times in a row, systemctl still reports RUNNING. '
+                    'Forcing restart.',
+                    self._pg_timeout_count,
+                )
 
         self.db.pgpooler('stop')
         if self._is_single_node:

--- a/src/main.py
+++ b/src/main.py
@@ -421,9 +421,6 @@ class pgconsul(object):
         stream_from = self.config.get('global', 'stream_from')
         if role is None:
             self.dead_iter(db_state, zk_state, is_in_terminal_state=terminal_state)
-            self.re_init_zk()
-            self.finish_iteration(timer)
-            return
         elif role == 'primary':
             if self._is_single_node:
                 self.single_node_primary_iter(db_state, zk_state)

--- a/src/main.py
+++ b/src/main.py
@@ -64,6 +64,13 @@ class pgconsul(object):
         # Used to decide when to force a restart (see run_iteration).
         self._pg_timeout_count: int = 0
         self._max_pg_timeouts: int = self.config.getint('global', 'max_conn_timeouts_before_restart')
+        if self._max_pg_timeouts < 1:
+            logging.warning(
+                'max_conn_timeouts_before_restart=%d is too low, falling back to 1. '
+                'Use 1 to restart on the first timeout (old behavior).',
+                self._max_pg_timeouts,
+            )
+            self._max_pg_timeouts = 1
 
     def _get_repllication_manager(self) -> ReplicationManager:
         if self.config.getboolean('global', 'quorum_commit'):
@@ -377,7 +384,7 @@ class pgconsul(object):
             db_state = {
                 'alive': False,
                 'running': pg_status == 0,
-                'prev_state': None,
+                'prev_state': self.db.get_cached_state(),
                 'connection_timeout': True,
             }
 

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from configparser import RawConfigParser
 
 from . import exceptions, helpers, sdnotify
 from .command_manager import CommandManager, Commands
+from .pg_conn_grace_period import PgConnGracePeriod
 from .failover_election import ElectionError, FailoverElection
 from .helpers import IterationTimer, get_hostname, register_sigterm_handler, should_run
 from .pg import Postgres, PostgresConfig
@@ -60,18 +61,9 @@ class pgconsul(object):
         self._debug_counters: dict[str, int] = {}
         self.last_zk_host_stat_write: float = 0
         self._replication_manager = self._get_repllication_manager()
-        # Restart threshold counter: consecutive iterations where Postgres
-        # connection timed out. Used to decide when to force a restart.
-        # Independent from _conn_timeout_count in pg.py (which drives backoff).
-        self._pg_timeout_count: int = 0
-        self._max_pg_timeouts: int = self.config.getint('global', 'max_conn_timeouts_before_restart')
-        if self._max_pg_timeouts < 1:
-            logging.warning(
-                'max_conn_timeouts_before_restart=%d is too low, falling back to 1. '
-                'Use 1 to restart on the first timeout (old behavior).',
-                self._max_pg_timeouts,
-            )
-            self._max_pg_timeouts = 1
+        self._pg_conn_grace = PgConnGracePeriod(
+            self.config.getint('global', 'pg_conn_failure_grace_period')
+        )
 
     def _get_repllication_manager(self) -> ReplicationManager:
         if self.config.getboolean('global', 'quorum_commit'):
@@ -370,15 +362,14 @@ class pgconsul(object):
 
         try:
             _, terminal_state = self.db.is_alive_and_in_terminal_state()
-            # Successful DB connection — reset the timeout counter.
-            self._pg_timeout_count = 0
+            self._pg_conn_grace.reset()
             if not terminal_state:
                 logging.debug('Database is starting up or shutting down')
             role = self.db.get_role()
             logging.info('Role: %s', str(role))
             db_state = self.db.get_state()
         except exceptions.PGConnectionTimeout:
-            self._pg_timeout_count += 1
+            self._pg_conn_grace.record_failure()
             try:
                 pg_running = self.db.is_postgresql_running()
             except Exception:
@@ -1072,26 +1063,8 @@ class pgconsul(object):
             return None
 
         if db_state.get('connection_timeout'):
-            if db_state.get('running') and self._pg_timeout_count < self._max_pg_timeouts:
-                logging.warning(
-                    'Connection to postgres failed (timeout), but systemctl reports it is RUNNING. '
-                    'Timeout count: %d/%d. Skipping restart.',
-                    self._pg_timeout_count,
-                    self._max_pg_timeouts,
-                )
+            if not self._pg_conn_grace.should_act(db_state.get('running', False)):
                 return None
-            if db_state.get('running'):
-                logging.error(
-                    'Connection to postgres failed %d times in a row, systemctl still reports RUNNING. '
-                    'Forcing restart.',
-                    self._pg_timeout_count,
-                )
-            else:
-                logging.error(
-                    'Connection timeout and process status unknown or process not running '
-                    '(systemctl unavailable or reported not running). '
-                    'Restarting immediately (timeout threshold bypassed).'
-                )
 
         self.db.pgpooler('stop')
         if self._is_single_node:

--- a/src/main.py
+++ b/src/main.py
@@ -1086,6 +1086,12 @@ class pgconsul(object):
                     'Forcing restart.',
                     self._pg_timeout_count,
                 )
+            else:
+                logging.error(
+                    'Connection timeout and process status unknown or process not running '
+                    '(systemctl unavailable or reported not running). '
+                    'Restarting immediately (timeout threshold bypassed).'
+                )
 
         self.db.pgpooler('stop')
         if self._is_single_node:

--- a/src/main.py
+++ b/src/main.py
@@ -370,16 +370,20 @@ class pgconsul(object):
 
         try:
             _, terminal_state = self.db.is_alive_and_in_terminal_state()
+            # Successful DB connection — reset the timeout counter.
+            self._pg_timeout_count = 0
             if not terminal_state:
                 logging.debug('Database is starting up or shutting down')
             role = self.db.get_role()
             logging.info('Role: %s', str(role))
             db_state = self.db.get_state()
-            # Successful DB interaction — reset the timeout counter.
-            self._pg_timeout_count = 0
         except exceptions.PGConnectionTimeout:
             self._pg_timeout_count += 1
-            pg_status = self.db.get_postgresql_status()
+            try:
+                pg_running = self.db.is_postgresql_running()
+            except Exception:
+                logging.error('Failed to get postgresql status during timeout handling')
+                pg_running = False
             role = None
             # True: skip the "waiting for startup/shutdown" branch in dead_iter().
             # Below threshold dead_iter() returns early; at threshold we want to
@@ -387,7 +391,7 @@ class pgconsul(object):
             terminal_state = True
             db_state = {
                 'alive': False,
-                'running': pg_status == 0,
+                'running': pg_running,
                 'prev_state': self.db.get_cached_state(),
                 'connection_timeout': True,
             }
@@ -1844,7 +1848,7 @@ class pgconsul(object):
             if is_db_alive:
                 logging.debug('PostgreSQL has completed recovery.')
                 return True
-            if self.db.get_postgresql_status() != 0:
+            if not self.db.is_postgresql_running():
                 logging.error('PostgreSQL service seems to be dead. No recovery is possible in this case.')
                 return False
             return None
@@ -2171,7 +2175,7 @@ class pgconsul(object):
 
         logging.warning('Stopping postgresql (wait for complete)')
         if self.stop_postgresql(force_async=False) != 0:
-            if self.db.get_postgresql_status() == 0:
+            if self.db.is_postgresql_running():
                 # pg is stopping, but still alive
                 logging.warning('unable to wait postgresql stopped')
 

--- a/src/main.py
+++ b/src/main.py
@@ -384,7 +384,7 @@ class pgconsul(object):
                 'alive': False,
                 'running': pg_running,
                 'prev_state': self.db.get_cached_state(),
-                'connection_timeout': True,
+                'connection_timed_out': True,
             }
 
         self.notifier.notify()
@@ -1054,7 +1054,7 @@ class pgconsul(object):
         """
         Iteration if local postgresql is dead.
 
-        When db_state['connection_timeout'] is True it means PostgreSQL process is
+        When db_state['connection_timed_out'] is True it means PostgreSQL process is
         reportedly running (systemctl) but pgconsul could not establish a psql
         connection. In that case we apply a consecutive-timeout threshold before
         allowing a restart.
@@ -1062,7 +1062,7 @@ class pgconsul(object):
         if not zk_state['alive'] or db_state['alive']:
             return None
 
-        if db_state.get('connection_timeout'):
+        if db_state.get('connection_timed_out'):
             if not self._pg_conn_grace.should_act(db_state.get('running', False)):
                 return None
 

--- a/src/pg.py
+++ b/src/pg.py
@@ -84,13 +84,15 @@ class Postgres(object):
         self.reconnect()
 
     def _create_cursor(self):
+        def _open_cursor():
+            cursor = self.conn_local.cursor()
+            cursor.execute('SELECT 1;')
+            return cursor
+
         try:
             if self.conn_local:
-                cursor = self.conn_local.cursor()
-                cursor.execute('SELECT 1;')
-                return cursor
-            else:
-                raise RuntimeError('Local conn is dead')
+                return _open_cursor()
+            raise RuntimeError('Local conn is dead')
         except Exception:
             try:
                 self.reconnect()
@@ -99,6 +101,11 @@ class Postgres(object):
                 # that callers can react to it (e.g. stop retrying) instead of
                 # silently incrementing _conn_timeout_count with no visible traceback.
                 raise
+            # reconnect() succeeded — create a fresh cursor and return it.
+            # Without this, _create_cursor() would fall through and return None.
+            if self.conn_local:
+                return _open_cursor()
+            raise RuntimeError('Local conn is dead after reconnect')
 
     def _exec_query(self, query, **kwargs):
         cur = self._create_cursor()
@@ -183,15 +190,14 @@ class Postgres(object):
         parts = [p for p in conn_string.split() if not p.startswith('connect_timeout=')]
         return ' '.join(parts)
 
-    def _get_conn_string_with_timeout(self) -> str:
-        """Build conn_string with dynamically computed connect_timeout (exponential backoff)."""
-        timeout = min(
+    def _get_current_timeout(self) -> int:
+        """Compute connect_timeout using exponential backoff (capped at LOCAL_CONNECT_TIMEOUT_MAX)."""
+        return min(
             self.LOCAL_CONNECT_TIMEOUT_INITIAL * (2 ** self._conn_timeout_count),
             self.LOCAL_CONNECT_TIMEOUT_MAX,
         )
-        return f'{self._base_conn_string} connect_timeout={timeout}'
 
-    def _log_connection_failure_diagnostics(self):
+    def _log_connection_failure_diagnostics(self, connect_timeout: int):
         """Log system diagnostics when PostgreSQL connection fails with timeout."""
         try:
             pg_status = self.get_postgresql_status()
@@ -219,10 +225,7 @@ class Postgres(object):
         logging.warning(
             'Connection timeout diagnostics: conn_timeout_count=%d, current_timeout=%d',
             self._conn_timeout_count,
-            min(
-                self.LOCAL_CONNECT_TIMEOUT_INITIAL * (2 ** self._conn_timeout_count),
-                self.LOCAL_CONNECT_TIMEOUT_MAX,
-            ),
+            connect_timeout,
         )
 
     def reconnect(self):
@@ -234,7 +237,8 @@ class Postgres(object):
             'FATAL:  the database system is starting up': exceptions.PGIsStartingUp,
             'FATAL:  the database system is shutting down': exceptions.PGIsShuttingDown,
         }
-        conn_str = self._get_conn_string_with_timeout()
+        connect_timeout = self._get_current_timeout()
+        conn_str = f'{self._base_conn_string} connect_timeout={connect_timeout}'
         try:
             if self.conn_local:
                 self.conn_local.close()
@@ -261,21 +265,23 @@ class Postgres(object):
                         raise exc()
             if 'timeout' in str(exception).lower():
                 self._conn_timeout_count += 1
-                self._log_connection_failure_diagnostics()
+                self._log_connection_failure_diagnostics(connect_timeout)
                 raise exceptions.PGConnectionTimeout(self._conn_timeout_count)
+
+    def get_cached_state(self):
+        """Read previously cached db_state from disk (or None if unavailable)."""
+        fname = '%s/.pgconsul_db_state.cache' % self.config.working_dir
+        try:
+            with open(fname, 'r') as fobj:
+                return json.loads(fobj.read())
+        except Exception:
+            return None
 
     def get_state(self):
         """
         Get current database state (if possible)
         """
-        fname = '%s/.pgconsul_db_state.cache' % self.config.working_dir
-        try:
-            with open(fname, 'r') as fobj:
-                prev = json.loads(fobj.read())
-        except Exception:
-            prev = None
-
-        data = {'alive': False, 'prev_state': prev}
+        data = {'alive': False, 'prev_state': self.get_cached_state()}
         try:
             try:
                 is_db_alive, terminal_state = self.is_alive_and_in_terminal_state()

--- a/src/pg.py
+++ b/src/pg.py
@@ -87,7 +87,8 @@ class Postgres(object):
 
     def _create_cursor(self):
         def _open_cursor():
-            assert self.conn_local is not None
+            if self.conn_local is None:
+                raise RuntimeError('Local conn is dead in _open_cursor()')
             cursor = self.conn_local.cursor()
             cursor.execute('SELECT 1;')
             return cursor
@@ -97,6 +98,8 @@ class Postgres(object):
                 return _open_cursor()
             raise RuntimeError('Local conn is dead')
         except Exception:
+            for line in traceback.format_exc().split('\n'):
+                logging.debug(line.rstrip())
             try:
                 self.reconnect()
             except exceptions.PGConnectionTimeout:
@@ -111,9 +114,8 @@ class Postgres(object):
             raise RuntimeError('Local conn is dead after reconnect')
 
     def _exec_query(self, query, **kwargs):
+        # _create_cursor() never returns None: it either returns a cursor or raises.
         cur = self._create_cursor()
-        if not cur:
-            raise RuntimeError('Local conn is dead')
         cur.execute(query, kwargs)
         return cur
 

--- a/src/pg.py
+++ b/src/pg.py
@@ -61,9 +61,9 @@ class Postgres(object):
     Postgres class
     """
 
+    DB_STATE_CACHE_FILENAME = '.pgconsul_db_state.cache'
     DISABLED_ARCHIVE_COMMAND = '/bin/false'
     DISABLED_RESTORE_COMMAND = '/bin/false'
-
     LOCAL_CONNECT_TIMEOUT_INITIAL = 1
     LOCAL_CONNECT_TIMEOUT_MAX = 10
 
@@ -87,6 +87,7 @@ class Postgres(object):
 
     def _create_cursor(self):
         def _open_cursor():
+            assert self.conn_local is not None
             cursor = self.conn_local.cursor()
             cursor.execute('SELECT 1;')
             return cursor
@@ -270,11 +271,14 @@ class Postgres(object):
                 self._log_connection_failure_diagnostics(connect_timeout)
                 raise exceptions.PGConnectionTimeout(self._conn_timeout_count)
 
+    @property
+    def _db_state_cache_path(self) -> str:
+        return os.path.join(self.config.working_dir, self.DB_STATE_CACHE_FILENAME)
+
     def get_cached_state(self):
         """Read previously cached db_state from disk (or None if unavailable)."""
-        fname = '%s/.pgconsul_db_state.cache' % self.config.working_dir
         try:
-            with open(fname, 'r') as fobj:
+            with open(self._db_state_cache_path, 'r') as fobj:
                 return json.loads(fobj.read())
         except Exception:
             return None
@@ -333,7 +337,7 @@ class Postgres(object):
 
         if data['alive']:
             try:
-                with open(fname, 'w') as fobj:
+                with open(self._db_state_cache_path, 'w') as fobj:
                     save_data = data.copy()
                     del save_data['prev_state']
                     fobj.write(json.dumps(save_data))

--- a/src/pg.py
+++ b/src/pg.py
@@ -64,6 +64,9 @@ class Postgres(object):
     DISABLED_ARCHIVE_COMMAND = '/bin/false'
     DISABLED_RESTORE_COMMAND = '/bin/false'
 
+    LOCAL_CONNECT_TIMEOUT_INITIAL = 1
+    LOCAL_CONNECT_TIMEOUT_MAX = 10
+
     def __init__(self, config: PostgresConfig, plugins: PluginRunner, cmd_manager: CommandManager):
         self.config = config
         self._plugins = plugins
@@ -75,6 +78,8 @@ class Postgres(object):
         self.role: str | None = None
         self.pgdata = ''
         self.pg_version = None
+        self._conn_timeout_count = 0
+        self._base_conn_string = self._strip_connect_timeout(config.conn_string)
         self._offline_detect_pgdata()
         self.reconnect()
 
@@ -87,9 +92,13 @@ class Postgres(object):
             else:
                 raise RuntimeError('Local conn is dead')
         except Exception:
-            for line in traceback.format_exc().split('\n'):
-                logging.debug(line.rstrip())
-            self.reconnect()
+            try:
+                self.reconnect()
+            except exceptions.PGConnectionTimeout:
+                # Timeout already logged and counted in reconnect(); re-raise so
+                # that callers can react to it (e.g. stop retrying) instead of
+                # silently incrementing _conn_timeout_count with no visible traceback.
+                raise
 
     def _exec_query(self, query, **kwargs):
         cur = self._create_cursor()
@@ -168,6 +177,54 @@ class Postgres(object):
         query = f"SELECT pg_drop_replication_slot('{slot_name}')"
         return self._exec_without_result(query)
 
+    @staticmethod
+    def _strip_connect_timeout(conn_string: str) -> str:
+        """Remove connect_timeout from conn_string to allow dynamic override."""
+        parts = [p for p in conn_string.split() if not p.startswith('connect_timeout=')]
+        return ' '.join(parts)
+
+    def _get_conn_string_with_timeout(self) -> str:
+        """Build conn_string with dynamically computed connect_timeout (exponential backoff)."""
+        timeout = min(
+            self.LOCAL_CONNECT_TIMEOUT_INITIAL * (2 ** self._conn_timeout_count),
+            self.LOCAL_CONNECT_TIMEOUT_MAX,
+        )
+        return f'{self._base_conn_string} connect_timeout={timeout}'
+
+    def _log_connection_failure_diagnostics(self):
+        """Log system diagnostics when PostgreSQL connection fails with timeout."""
+        try:
+            pg_status = self.get_postgresql_status()
+            logging.warning('Connection timeout diagnostics: pg_status=%s', pg_status)
+        except Exception:
+            logging.warning('Connection timeout diagnostics: could not get pg_status')
+        try:
+            cpu_count = os.cpu_count() or 'unknown'
+            with open('/proc/loadavg', 'r') as f:
+                logging.warning(
+                    'Connection timeout diagnostics: loadavg=%s cpu_count=%s',
+                    f.read().strip(),
+                    cpu_count,
+                )
+        except Exception:
+            pass
+        for pressure_file in ('/proc/pressure/cpu', '/proc/pressure/io'):
+            try:
+                with open(pressure_file, 'r') as f:
+                    logging.warning(
+                        'Connection timeout diagnostics: %s=%s', pressure_file, f.read().strip()
+                    )
+            except Exception:
+                pass
+        logging.warning(
+            'Connection timeout diagnostics: conn_timeout_count=%d, current_timeout=%d',
+            self._conn_timeout_count,
+            min(
+                self.LOCAL_CONNECT_TIMEOUT_INITIAL * (2 ** self._conn_timeout_count),
+                self.LOCAL_CONNECT_TIMEOUT_MAX,
+            ),
+        )
+
     def reconnect(self):
         """
         Reestablish connection with local postgresql
@@ -177,6 +234,7 @@ class Postgres(object):
             'FATAL:  the database system is starting up': exceptions.PGIsStartingUp,
             'FATAL:  the database system is shutting down': exceptions.PGIsShuttingDown,
         }
+        conn_str = self._get_conn_string_with_timeout()
         try:
             if self.conn_local:
                 self.conn_local.close()
@@ -184,14 +242,15 @@ class Postgres(object):
                 logging.error('PostgreSQL is dead. Unable to reconnect.')
                 self.conn_local = None
                 return
-            self.conn_local = psycopg2.connect(self.config.conn_string)
+            self.conn_local = psycopg2.connect(conn_str)
             self.conn_local.autocommit = True
 
+            self._conn_timeout_count = 0
             self.role = self.get_role()
             self.pg_version = self._get_pg_version()
             self.pgdata = self._get_pgdata_path()
-        except psycopg2.OperationalError:
-            logging.error('Could not connect to "%s".', self.config.conn_string)
+        except psycopg2.OperationalError as exception:
+            logging.error('Could not connect to "%s".', conn_str)
             self.conn_local = None
             error_lines = traceback.format_exc().split('\n')
             for line in error_lines:
@@ -200,6 +259,10 @@ class Postgres(object):
                 for substr, exc in nonfatal_errors.items():
                     if substr in line:
                         raise exc()
+            if 'timeout' in str(exception).lower():
+                self._conn_timeout_count += 1
+                self._log_connection_failure_diagnostics()
+                raise exceptions.PGConnectionTimeout(self._conn_timeout_count)
 
     def get_state(self):
         """
@@ -222,6 +285,8 @@ class Postgres(object):
                 else:
                     data['running'] = True
                     data['alive'] = False
+            except exceptions.PGConnectionTimeout:
+                raise
             except Exception:
                 data['running'] = False
                 data['alive'] = False
@@ -252,6 +317,8 @@ class Postgres(object):
             # unpredictable results.
             #
             data['alive'] = self.is_alive()
+        except exceptions.PGConnectionTimeout:
+            raise
         except Exception:
             for line in traceback.format_exc().split('\n'):
                 logging.error(line.rstrip())
@@ -273,7 +340,10 @@ class Postgres(object):
 
     def is_alive_and_in_terminal_state(self):
         """
-        Check that postgresql is alive
+        Check that postgresql is alive.
+
+        Raises PGConnectionTimeout when a connection attempt timed out — the caller
+        is responsible for the restart policy (how many timeouts to tolerate).
         """
         try:
             # In order to check that postgresql is really alive
@@ -289,9 +359,11 @@ class Postgres(object):
             return False, True
         except (exceptions.PGIsShuttingDown, exceptions.PGIsStartingUp):
             return False, False
+        except exceptions.PGConnectionTimeout:
+            raise
         except Exception:
             for line in traceback.format_exc().split('\n'):
-                logging.debug(line.rstrip())
+                logging.warning(line.rstrip())
             return False, True
 
     def get_role(self):

--- a/src/pg.py
+++ b/src/pg.py
@@ -367,7 +367,7 @@ class Postgres(object):
                 if res[0] == 42:
                     return True, True
             else:
-                self.state['running'] = self.get_postgresql_status() == 0
+                self.state['running'] = self.is_postgresql_running()
             return False, True
         except (exceptions.PGIsShuttingDown, exceptions.PGIsStartingUp):
             return False, False
@@ -375,7 +375,7 @@ class Postgres(object):
             raise
         except Exception:
             for line in traceback.format_exc().split('\n'):
-                logging.warning(line.rstrip())
+                logging.debug(line.rstrip())
             return False, True
 
     def get_role(self):
@@ -849,6 +849,10 @@ class Postgres(object):
         Returns PG status on current host
         """
         return self._cmd_manager.get_postgresql_status(self.pgdata)
+
+    def is_postgresql_running(self) -> bool:
+        """Returns True if PostgreSQL process is running (systemctl status == 0)."""
+        return self.get_postgresql_status() == 0
 
     def stop_postgresql(self, timeout=60, wait=True):
         """

--- a/src/pg.py
+++ b/src/pg.py
@@ -78,6 +78,8 @@ class Postgres(object):
         self.role: str | None = None
         self.pgdata = ''
         self.pg_version = None
+        # Backoff counter for connect_timeout (1→2→4→8→10s). Reset on success.
+        # Independent from _pg_timeout_count in main.py (restart threshold).
         self._conn_timeout_count = 0
         self._base_conn_string = self._strip_connect_timeout(config.conn_string)
         self._offline_detect_pgdata()

--- a/src/pg.py
+++ b/src/pg.py
@@ -79,7 +79,6 @@ class Postgres(object):
         self.pgdata = ''
         self.pg_version = None
         # Backoff counter for connect_timeout (1→2→4→8→10s). Reset on success.
-        # Independent from _pg_timeout_count in main.py (restart threshold).
         self._conn_timeout_count = 0
         self._base_conn_string = self._strip_connect_timeout(config.conn_string)
         self._offline_detect_pgdata()
@@ -204,34 +203,29 @@ class Postgres(object):
 
     def _log_connection_failure_diagnostics(self, connect_timeout: int):
         """Log system diagnostics when PostgreSQL connection fails with timeout."""
+        prefix = 'Connection timeout diagnostics:'
         try:
             pg_status = self.get_postgresql_status()
-            logging.warning('Connection timeout diagnostics: pg_status=%s', pg_status)
+            logging.warning(
+                f'{prefix} pg_status={pg_status} (postgres is {"alive" if pg_status == 0 else "not alive"})'
+            )
         except Exception:
-            logging.warning('Connection timeout diagnostics: could not get pg_status')
+            logging.warning(f'{prefix} could not get pg_status')
+
         try:
-            cpu_count = os.cpu_count() or 'unknown'
             with open('/proc/loadavg', 'r') as f:
-                logging.warning(
-                    'Connection timeout diagnostics: loadavg=%s cpu_count=%s',
-                    f.read().strip(),
-                    cpu_count,
-                )
+                logging.warning(f'{prefix} loadavg={f.read().strip()} cpu_count={os.cpu_count() or "unknown"}')
         except Exception:
             pass
+
         for pressure_file in ('/proc/pressure/cpu', '/proc/pressure/io'):
             try:
                 with open(pressure_file, 'r') as f:
-                    logging.warning(
-                        'Connection timeout diagnostics: %s=%s', pressure_file, f.read().strip()
-                    )
+                    logging.warning(f'{prefix} {pressure_file}={f.read().strip()}')
             except Exception:
                 pass
-        logging.warning(
-            'Connection timeout diagnostics: conn_timeout_count=%d, current_timeout=%d',
-            self._conn_timeout_count,
-            connect_timeout,
-        )
+
+        logging.warning(f'{prefix} conn_timeout_count={self._conn_timeout_count}, current_timeout={connect_timeout}')
 
     def reconnect(self):
         """
@@ -263,7 +257,7 @@ class Postgres(object):
             self.conn_local = None
             error_lines = traceback.format_exc().split('\n')
             for line in error_lines:
-                logging.error(line.rstrip())
+                logging.debug(line.rstrip())
             for line in error_lines:
                 for substr, exc in nonfatal_errors.items():
                     if substr in line:

--- a/src/pg_conn_grace_period.py
+++ b/src/pg_conn_grace_period.py
@@ -1,0 +1,64 @@
+# encoding: utf-8
+import logging
+import time
+
+
+class PgConnGracePeriod:
+    """
+    Tracks consecutive PG connection-timeout failures.
+    Decides whether to act immediately or wait out the grace period.
+    """
+
+    def __init__(self, grace_period: int) -> None:
+        if grace_period < 0:
+            logging.warning(
+                'pg_conn_failure_grace_period=%.1f is negative, falling back to 0 '
+                '(act immediately on first connection failure).',
+                grace_period,
+            )
+            grace_period = 0
+        self._grace_period = grace_period
+        self._first_failure_ts: float | None = None
+
+    def reset(self) -> None:
+        """Call on every successful DB connection."""
+        self._first_failure_ts = None
+
+    def record_failure(self) -> None:
+        """Call on PGConnectionTimeout. Keeps the timestamp of the *first* failure."""
+        if self._first_failure_ts is None:
+            self._first_failure_ts = time.time()
+
+    def should_act(self, pg_running: bool) -> bool:
+        """
+        Returns True when it is time to force action (restart etc.).
+        pg_running: whether systemctl reports the process as running.
+        """
+        if self._first_failure_ts is None:
+            return True
+
+        elapsed = time.time() - self._first_failure_ts
+
+        if pg_running and elapsed < self._grace_period:
+            logging.warning(
+                'Connection to postgres failed (timeout), but systemctl reports it is RUNNING. '
+                'Elapsed since first failure: %.1fs / grace period: %.1fs. Skipping.',
+                elapsed,
+                self._grace_period,
+            )
+            return False
+
+        if pg_running:
+            logging.error(
+                'Connection to postgres failed for %.1fs (grace period: %.1fs), '
+                'systemctl still reports RUNNING. Forcing action.',
+                elapsed,
+                self._grace_period,
+            )
+        else:
+            logging.error(
+                'Connection timeout and process status unknown or process not running '
+                '(systemctl unavailable or reported not running). '
+                'Restarting immediately (timeout threshold bypassed).'
+            )
+        return True

--- a/src/pg_conn_grace_period.py
+++ b/src/pg_conn_grace_period.py
@@ -12,7 +12,7 @@ class PgConnGracePeriod:
     def __init__(self, grace_period: int) -> None:
         if grace_period < 0:
             logging.warning(
-                'pg_conn_failure_grace_period=%.1f is negative, falling back to 0 '
+                'pg_conn_failure_grace_period=%d is negative, falling back to 0 '
                 '(act immediately on first connection failure).',
                 grace_period,
             )
@@ -42,7 +42,7 @@ class PgConnGracePeriod:
         if pg_running and elapsed < self._grace_period:
             logging.warning(
                 'Connection to postgres failed (timeout), but systemctl reports it is RUNNING. '
-                'Elapsed since first failure: %.1fs / grace period: %.1fs. Skipping.',
+                'Elapsed since first failure: %.1fs / grace period: %ds. Skipping.',
                 elapsed,
                 self._grace_period,
             )
@@ -50,7 +50,7 @@ class PgConnGracePeriod:
 
         if pg_running:
             logging.error(
-                'Connection to postgres failed for %.1fs (grace period: %.1fs), '
+                'Connection to postgres failed for %.1fs (grace period: %ds), '
                 'systemctl still reports RUNNING. Forcing action.',
                 elapsed,
                 self._grace_period,

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -3,9 +3,9 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
     # Regression test for MDB-46149.
     #
     # Bug: connection timeout was treated as "postgres dead" → dead_iter() → restart.
-    # Fix: run_iteration() catches PGConnectionTimeout, counts it (_pg_timeout_count
-    # in main.py, threshold = max_conn_timeouts_before_restart). Below threshold and
-    # process alive → "Skipping restart". At threshold → "Forcing restart".
+    # Fix: run_iteration() catches PGConnectionTimeout, records first failure timestamp
+    # (_pg_first_failure_ts in main.py, grace period = pg_conn_failure_grace_period seconds).
+    # While elapsed < grace period and process alive → "Skipping". At grace period → "Forcing action.".
     # pg.py uses _conn_timeout_count for exponential connect_timeout backoff (1→2→4→8→10 s).
 
     @skipping_restart
@@ -17,7 +17,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
                     priority: 0
                     use_replication_slots: 'yes'
                     quorum_commit: 'yes'
-                    max_conn_timeouts_before_restart: 5
+                    pg_conn_failure_grace_period: 30
                 primary:
                     change_replication_type: 'yes'
                     primary_switch_checks: 1
@@ -55,9 +55,9 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
 
         When we remember postgresql start time in container "postgresql1"
 
-        # --- Phase 1: first overload below threshold (max_conn_timeouts_before_restart=5) ---
+        # --- Phase 1: first overload within grace period (pg_conn_failure_grace_period=30s) ---
         # SIGSTOP simulates overload: process alive (systemctl=running) but connection times out.
-        # budget=1+2+4+8+10=25s. 5s → ~2 timeouts, below threshold.
+        # 5s elapsed < 30s grace period → Skipping.
         When we kill "postgres" in container "postgresql1" with signal "STOP"
         When we wait "5.0" seconds
         When we kill "postgres" in container "postgresql1" with signal "CONT"
@@ -66,13 +66,13 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
-        Skipping restart
+        Skipping.
         """
 
-        # Wait for pgconsul to reconnect successfully — this resets the timeout counter.
+        # Wait for pgconsul to reconnect successfully — this resets the grace period timer.
         When we wait "5.0" seconds
 
-        # --- Phase 2: second overload — counter must have been reset, so "Skipping restart" again (not "Forcing restart") ---
+        # --- Phase 2: second overload — timer must have been reset, so "Skipping." again (not "Forcing action.") ---
         When we kill "postgres" in container "postgresql1" with signal "STOP"
         When we wait "5.0" seconds
         When we kill "postgres" in container "postgresql1" with signal "CONT"
@@ -82,8 +82,8 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
-        Skipping restart
-        Skipping restart
+        Skipping.
+        Skipping.
         """
 
         # No failover: lock held, postgres not restarted.
@@ -103,7 +103,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
                     priority: 0
                     use_replication_slots: 'yes'
                     quorum_commit: 'yes'
-                    max_conn_timeouts_before_restart: 3
+                    pg_conn_failure_grace_period: 7
                 primary:
                     change_replication_type: 'yes'
                     primary_switch_checks: 1
@@ -144,14 +144,14 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
 
         When we remember postgresql start time in container "postgresql1"
 
-        # max_conn_timeouts_before_restart=3, budget=1+2+4=7s. After 3 timeouts → "Forcing restart".
+        # pg_conn_failure_grace_period=7s. After 7s elapsed → "Forcing action.".
         When we kill "postgres" in container "postgresql1" with signal "STOP"
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
-        Skipping restart
-        Forcing restart
+        Skipping.
+        Forcing action.
         Called: stop_pooler
         Called: start_postgresql
         """
@@ -165,8 +165,8 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         And container "postgresql3" is a replica of container "postgresql1"
 
     @skipping_restart
-    Scenario: Overloaded replica is not restarted while systemctl reports it running using default max_conn_timeouts_before_restart
-        # max_conn_timeouts_before_restart is NOT set in config — verifies the default value is applied.
+    Scenario: Overloaded replica is not restarted while systemctl reports it running using default pg_conn_failure_grace_period
+        # pg_conn_failure_grace_period is NOT set in config — verifies the default value (30.0s) is applied.
         Given a "pgconsul" container common config
         """
             pgconsul.conf:
@@ -214,7 +214,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         # SIGSTOP simulates overload on replica: process alive (systemctl=running) but connection times out.
         When we kill "postgres" in container "postgresql2" with signal "STOP"
 
-        # max_conn_timeouts_before_restart=5, budget=1+2+4+8+10=25s. 15s → ~3-4 timeouts, below threshold.
+        # pg_conn_failure_grace_period=30s (default). 15s elapsed < 30s → Skipping.
         When we wait "15.0" seconds
 
         # Unfreeze postgres.
@@ -224,7 +224,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
-        Skipping restart
+        Skipping.
         """
 
         # No failover: primary lock unchanged, replica not restarted.

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -2,27 +2,11 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
 
     # Regression test for MDB-46149.
     #
-    # Root cause: when pgconsul cannot connect to local postgres due to connect_timeout
-    # (e.g. postgres is alive but overloaded), it wrongly assumes postgres is dead and
-    # calls dead_iter() which stops odyssey and restarts postgres — unnecessary downtime.
-    #
-    # Chain of events that triggers the bug:
-    #   run_iteration()
-    #     → db.get_state()
-    #         → is_alive_and_in_terminal_state()
-    #             → reconnect()  ← connect_timeout=1 → OperationalError: timeout expired
-    #         → raises RuntimeError: PostgreSQL is dead
-    #     → get_role() → None
-    #     → dead_iter()
-    #         → pgpooler('stop')    ← stops odyssey
-    #         → start_postgresql()  ← restarts postgres
-    #
-    # Fix: pgconsul now tracks consecutive connection timeouts (_conn_timeout_count).
-    # If the postgres process is alive (get_postgresql_status() == 0) and the counter
-    # is below max_conn_timeouts_before_restart, pgconsul logs a warning and skips the
-    # restart, returning (True, True) from is_alive_and_in_terminal_state().
-    # The connect_timeout grows exponentially (1 → 2 → 4 → 8 → 10 s) so that a
-    # temporarily overloaded postgres gets more time to respond on each retry.
+    # Bug: connection timeout was treated as "postgres dead" → dead_iter() → restart.
+    # Fix: run_iteration() catches PGConnectionTimeout, counts it (_pg_timeout_count
+    # in main.py, threshold = max_conn_timeouts_before_restart). Below threshold and
+    # process alive → "Skipping restart". At threshold → "Forcing restart".
+    # pg.py uses _conn_timeout_count for exponential connect_timeout backoff (1→2→4→8→10 s).
 
     @skipping_restart
     Scenario: Overloaded primary is not restarted while systemctl reports it running
@@ -69,42 +53,28 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
         And container "postgresql3" is a replica of container "postgresql1"
         And "pgbouncer" is running in container "postgresql1"
 
-        # Remember the postgres process start time so we can assert it was NOT restarted later.
         When we remember postgresql start time in container "postgresql1"
 
-        # Simulate postgres overload with SIGSTOP: the process is paused but remains visible
-        # to systemctl as "running". pgconsul cannot open a new connection (connect_timeout
-        # fires), which is indistinguishable from a fully-loaded postgres that is too busy
-        # to accept connections.
+        # SIGSTOP simulates overload: process alive (systemctl=running) but connection times out.
         When we kill "postgres" in container "postgresql1" with signal "STOP"
 
-        # Wait long enough for pgconsul to accumulate several connection-timeout attempts
-        # but well below the total time needed to exhaust the restart threshold.
-        # With max_conn_timeouts_before_restart=5 and exponential back-off the full
-        # timeout budget is 1+2+4+8+10 = 25 s, so 15 s gives ~3-4 failed attempts.
+        # max_conn_timeouts_before_restart=5, budget=1+2+4+8+10=25s. 15s → ~3-4 timeouts, below threshold.
         When we wait "15.0" seconds
 
-        # Unfreeze postgres — it resumes and starts accepting connections again.
+        # Unfreeze postgres.
         When we kill "postgres" in container "postgresql1" with signal "CONT"
 
-        # pgconsul must detect that postgres is still alive via systemctl and skip the restart.
-        # Then container "postgresql1" pgconsul log contains "Skipping restart"
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
         Skipping restart
+        Role: primary
         """
 
-        # The primary ZK lock must still be held — pgconsul keeps running even while
-        # postgres is frozen, so no failover should have been triggered.
+        # No failover: lock held, postgres not restarted.
         And zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
 
-        # After recovery the cluster must be fully healthy:
-        #   - postgresql1 is still the primary (no failover occurred)
-        #   - postgres was NOT restarted (start time unchanged)
-        #   - odyssey/pgbouncer is still running (dead_iter was never called)
-        #   - replicas are streaming from postgresql1
         Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         And container "postgresql1" became a primary
         And postgresql in container "postgresql1" was not restarted
@@ -131,7 +101,9 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
                     min_failover_timeout: 120
                     primary_unavailability_timeout: 2
                 commands:
-                    # pg_start: /usr/bin/postgresql/pg_ctl restart -s -w -t %t -D %p --log=/var/log/postgresql/postgresql.log
+                    # Wrapper: unfreeze (SIGCONT all postgres), stop, then start — needed because
+                    # frozen postgres holds pid file/shared memory, so plain pg_ctl start fails.
+                    pg_start: bash -c 'pkill -CONT postgres 2>/dev/null; /usr/bin/postgresql/pg_ctl stop -s -m fast -w -t 10 -D %p 2>/dev/null; exec /usr/bin/postgresql/pg_ctl start -s -w -t %t -D %p --log=/var/log/postgresql/postgresql.log'
                     generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
         """
         Given a following cluster with "zookeeper" with replication slots
@@ -158,20 +130,13 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
         And container "postgresql3" is a replica of container "postgresql1"
         And "pgbouncer" is running in container "postgresql1"
 
-        # Remember start time — it MUST change after forced restart.
         When we remember postgresql start time in container "postgresql1"
 
-        # Freeze postgres. With max_conn_timeouts_before_restart=3 the exponential
-        # timeout budget is 1+2+4 = 7 s. After 3 consecutive timeouts pgconsul
-        # should log "Forcing restart" and call dead_iter() unconditionally.
+        # max_conn_timeouts_before_restart=3, budget=1+2+4=7s. After 3 timeouts → "Forcing restart".
         When we kill "postgres" in container "postgresql1" with signal "STOP"
 
-        # 10 s is well above the 7 s budget plus iteration overhead.
-        And we wait "10.0" seconds
-        # Unfreeze so that postgres can actually come back up after the restart.
-        When we kill "postgres" in container "postgresql1" with signal "CONT"
+        And we wait "15.0" seconds
 
-        # pgconsul must log "Forcing restart" once the counter is exhausted.
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
@@ -182,12 +147,8 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
         Called: start_postgresql
         """
 
-        When we wait "30.0" seconds
-
-        # After recovery the cluster must be fully healthy:
-        #   - postgresql1 is still the primary (no failover occurred)
-        #   - odyssey/pgbouncer is still running (dead_iter was never called)
-        #   - replicas are streaming from postgresql1
+        # postgresql1 restarted, remains primary.
+        Then postgresql in container "postgresql1" was restarted
         Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         And container "postgresql1" became a primary
         And "pgbouncer" is running in container "postgresql1"

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -1,4 +1,4 @@
-Feature: Overloaded primary postgres is not restarted by pgconsul
+Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
 
     # Regression test for MDB-46149.
     #
@@ -9,7 +9,7 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
     # pg.py uses _conn_timeout_count for exponential connect_timeout backoff (1→2→4→8→10 s).
 
     @skipping_restart
-    Scenario: Overloaded primary is not restarted while systemctl reports it running
+    Scenario: Overloaded primary is not restarted while systemctl reports it running and timeout counter is reset after successful reconnection
         Given a "pgconsul" container common config
         """
             pgconsul.conf:
@@ -55,13 +55,11 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
 
         When we remember postgresql start time in container "postgresql1"
 
+        # --- Phase 1: first overload below threshold (max_conn_timeouts_before_restart=5) ---
         # SIGSTOP simulates overload: process alive (systemctl=running) but connection times out.
+        # budget=1+2+4+8+10=25s. 5s → ~2 timeouts, below threshold.
         When we kill "postgres" in container "postgresql1" with signal "STOP"
-
-        # max_conn_timeouts_before_restart=5, budget=1+2+4+8+10=25s. 15s → ~3-4 timeouts, below threshold.
-        When we wait "15.0" seconds
-
-        # Unfreeze postgres.
+        When we wait "5.0" seconds
         When we kill "postgres" in container "postgresql1" with signal "CONT"
 
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
@@ -69,13 +67,27 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
         Connection timeout diagnostics: pg_status=0
         Skipping restart
-        Role: primary
+        """
+
+        # Wait for pgconsul to reconnect successfully — this resets the timeout counter.
+        When we wait "5.0" seconds
+
+        # --- Phase 2: second overload — counter must have been reset, so "Skipping restart" again (not "Forcing restart") ---
+        When we kill "postgres" in container "postgresql1" with signal "STOP"
+        When we wait "5.0" seconds
+        When we kill "postgres" in container "postgresql1" with signal "CONT"
+
+        # The second "Skipping restart" after a successful reconnection proves the counter was reset.
+        Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
+        """
+        psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
+        Connection timeout diagnostics: pg_status=0
+        Skipping restart
+        Skipping restart
         """
 
         # No failover: lock held, postgres not restarted.
         And zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
-
-        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         And container "postgresql1" became a primary
         And postgresql in container "postgresql1" was not restarted
         And "pgbouncer" is running in container "postgresql1"
@@ -152,5 +164,75 @@ Feature: Overloaded primary postgres is not restarted by pgconsul
         Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         And container "postgresql1" became a primary
         And "pgbouncer" is running in container "postgresql1"
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"
+
+    @skipping_restart
+    Scenario: Overloaded replica is not restarted while systemctl reports it running using default max_conn_timeouts_before_restart
+        # max_conn_timeouts_before_restart is NOT set in config — verifies the default value is applied.
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: 'yes'
+                    quorum_commit: 'yes'
+                primary:
+                    change_replication_type: 'yes'
+                    primary_switch_checks: 1
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_switch_checks: 1
+                    min_failover_timeout: 120
+                    primary_unavailability_timeout: 2
+                commands:
+                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
+        """
+        Given a following cluster with "zookeeper" with replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 2
+            postgresql3:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 1
+        """
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql2" is in quorum group
+        And container "postgresql3" is in quorum group
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"
+        And "pgbouncer" is running in container "postgresql2"
+
+        When we remember postgresql start time in container "postgresql2"
+
+        # SIGSTOP simulates overload on replica: process alive (systemctl=running) but connection times out.
+        When we kill "postgres" in container "postgresql2" with signal "STOP"
+
+        # max_conn_timeouts_before_restart=5, budget=1+2+4+8+10=25s. 15s → ~3-4 timeouts, below threshold.
+        When we wait "15.0" seconds
+
+        # Unfreeze postgres.
+        When we kill "postgres" in container "postgresql2" with signal "CONT"
+
+        Then container "postgresql2" pgconsul log contains messages in order within "60" seconds
+        """
+        psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
+        Connection timeout diagnostics: pg_status=0
+        Skipping restart
+        """
+
+        # No failover: primary lock unchanged, replica not restarted.
+        And zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And postgresql in container "postgresql2" was not restarted
+        And "pgbouncer" is running in container "postgresql2"
         And container "postgresql2" is a replica of container "postgresql1"
         And container "postgresql3" is a replica of container "postgresql1"

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -1,0 +1,195 @@
+Feature: Overloaded primary postgres is not restarted by pgconsul
+
+    # Regression test for MDB-46149.
+    #
+    # Root cause: when pgconsul cannot connect to local postgres due to connect_timeout
+    # (e.g. postgres is alive but overloaded), it wrongly assumes postgres is dead and
+    # calls dead_iter() which stops odyssey and restarts postgres — unnecessary downtime.
+    #
+    # Chain of events that triggers the bug:
+    #   run_iteration()
+    #     → db.get_state()
+    #         → is_alive_and_in_terminal_state()
+    #             → reconnect()  ← connect_timeout=1 → OperationalError: timeout expired
+    #         → raises RuntimeError: PostgreSQL is dead
+    #     → get_role() → None
+    #     → dead_iter()
+    #         → pgpooler('stop')    ← stops odyssey
+    #         → start_postgresql()  ← restarts postgres
+    #
+    # Fix: pgconsul now tracks consecutive connection timeouts (_conn_timeout_count).
+    # If the postgres process is alive (get_postgresql_status() == 0) and the counter
+    # is below max_conn_timeouts_before_restart, pgconsul logs a warning and skips the
+    # restart, returning (True, True) from is_alive_and_in_terminal_state().
+    # The connect_timeout grows exponentially (1 → 2 → 4 → 8 → 10 s) so that a
+    # temporarily overloaded postgres gets more time to respond on each retry.
+
+    @skipping_restart
+    Scenario: Overloaded primary is not restarted while systemctl reports it running
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: 'yes'
+                    quorum_commit: 'yes'
+                    max_conn_timeouts_before_restart: 5
+                primary:
+                    change_replication_type: 'yes'
+                    primary_switch_checks: 1
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_switch_checks: 1
+                    min_failover_timeout: 120
+                    primary_unavailability_timeout: 2
+                commands:
+                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
+        """
+        Given a following cluster with "zookeeper" with replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 2
+            postgresql3:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 1
+        """
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql2" is in quorum group
+        And container "postgresql3" is in quorum group
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"
+        And "pgbouncer" is running in container "postgresql1"
+
+        # Remember the postgres process start time so we can assert it was NOT restarted later.
+        When we remember postgresql start time in container "postgresql1"
+
+        # Simulate postgres overload with SIGSTOP: the process is paused but remains visible
+        # to systemctl as "running". pgconsul cannot open a new connection (connect_timeout
+        # fires), which is indistinguishable from a fully-loaded postgres that is too busy
+        # to accept connections.
+        When we kill "postgres" in container "postgresql1" with signal "STOP"
+
+        # Wait long enough for pgconsul to accumulate several connection-timeout attempts
+        # but well below the total time needed to exhaust the restart threshold.
+        # With max_conn_timeouts_before_restart=5 and exponential back-off the full
+        # timeout budget is 1+2+4+8+10 = 25 s, so 15 s gives ~3-4 failed attempts.
+        When we wait "15.0" seconds
+
+        # Unfreeze postgres — it resumes and starts accepting connections again.
+        When we kill "postgres" in container "postgresql1" with signal "CONT"
+
+        # pgconsul must detect that postgres is still alive via systemctl and skip the restart.
+        # Then container "postgresql1" pgconsul log contains "Skipping restart"
+        Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
+        """
+        psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
+        Connection timeout diagnostics: pg_status=0
+        Skipping restart
+        """
+
+        # The primary ZK lock must still be held — pgconsul keeps running even while
+        # postgres is frozen, so no failover should have been triggered.
+        And zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+
+        # After recovery the cluster must be fully healthy:
+        #   - postgresql1 is still the primary (no failover occurred)
+        #   - postgres was NOT restarted (start time unchanged)
+        #   - odyssey/pgbouncer is still running (dead_iter was never called)
+        #   - replicas are streaming from postgresql1
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql1" became a primary
+        And postgresql in container "postgresql1" was not restarted
+        And "pgbouncer" is running in container "postgresql1"
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"
+
+    @forcing_restart
+    Scenario: Overloaded primary IS restarted after exhausting connection timeout budget
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: 'yes'
+                    quorum_commit: 'yes'
+                    max_conn_timeouts_before_restart: 3
+                primary:
+                    change_replication_type: 'yes'
+                    primary_switch_checks: 1
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_switch_checks: 1
+                    min_failover_timeout: 120
+                    primary_unavailability_timeout: 2
+                commands:
+                    # pg_start: /usr/bin/postgresql/pg_ctl restart -s -w -t %t -D %p --log=/var/log/postgresql/postgresql.log
+                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
+        """
+        Given a following cluster with "zookeeper" with replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 2
+            postgresql3:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 1
+        """
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql2" is in quorum group
+        And container "postgresql3" is in quorum group
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"
+        And "pgbouncer" is running in container "postgresql1"
+
+        # Remember start time — it MUST change after forced restart.
+        When we remember postgresql start time in container "postgresql1"
+
+        # Freeze postgres. With max_conn_timeouts_before_restart=3 the exponential
+        # timeout budget is 1+2+4 = 7 s. After 3 consecutive timeouts pgconsul
+        # should log "Forcing restart" and call dead_iter() unconditionally.
+        When we kill "postgres" in container "postgresql1" with signal "STOP"
+
+        # 10 s is well above the 7 s budget plus iteration overhead.
+        And we wait "10.0" seconds
+        # Unfreeze so that postgres can actually come back up after the restart.
+        When we kill "postgres" in container "postgresql1" with signal "CONT"
+
+        # pgconsul must log "Forcing restart" once the counter is exhausted.
+        Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
+        """
+        psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
+        Connection timeout diagnostics: pg_status=0
+        Skipping restart
+        Forcing restart
+        Called: stop_pooler
+        Called: start_postgresql
+        """
+
+        When we wait "30.0" seconds
+
+        # After recovery the cluster must be fully healthy:
+        #   - postgresql1 is still the primary (no failover occurred)
+        #   - odyssey/pgbouncer is still running (dead_iter was never called)
+        #   - replicas are streaming from postgresql1
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql1" became a primary
+        And "pgbouncer" is running in container "postgresql1"
+        And container "postgresql2" is a replica of container "postgresql1"
+        And container "postgresql3" is a replica of container "postgresql1"

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -8,7 +8,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
     # While elapsed < grace period and process alive → "Skipping". At grace period → "Forcing action.".
     # pg.py uses _conn_timeout_count for exponential connect_timeout backoff (1→2→4→8→10 s).
 
-    @skipping_restart
+    @skipping_restart @skipping_restart_primary
     Scenario: Overloaded primary is not restarted while systemctl reports it running and timeout counter is reset after successful reconnection
         Given a "pgconsul" container common config
         """
@@ -59,7 +59,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         # SIGSTOP simulates overload: process alive (systemctl=running) but connection times out.
         # 5s elapsed < 30s grace period → Skipping.
         When we kill "postgres" in container "postgresql1" with signal "STOP"
-        When we wait "5.0" seconds
+        When we wait "15.0" seconds
         When we kill "postgres" in container "postgresql1" with signal "CONT"
 
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
@@ -74,7 +74,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
 
         # --- Phase 2: second overload — timer must have been reset, so "Skipping." again (not "Forcing action.") ---
         When we kill "postgres" in container "postgresql1" with signal "STOP"
-        When we wait "5.0" seconds
+        When we wait "15.0" seconds
         When we kill "postgres" in container "postgresql1" with signal "CONT"
 
         # The second "Skipping restart" after a successful reconnection proves the counter was reset.
@@ -164,7 +164,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         And container "postgresql2" is a replica of container "postgresql1"
         And container "postgresql3" is a replica of container "postgresql1"
 
-    @skipping_restart
+    @skipping_restart @skipping_restart_replica
     Scenario: Overloaded replica is not restarted while systemctl reports it running using default pg_conn_failure_grace_period
         # pg_conn_failure_grace_period is NOT set in config — verifies the default value (30.0s) is applied.
         Given a "pgconsul" container common config

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -146,9 +146,6 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
 
         # max_conn_timeouts_before_restart=3, budget=1+2+4=7s. After 3 timeouts → "Forcing restart".
         When we kill "postgres" in container "postgresql1" with signal "STOP"
-
-        And we wait "15.0" seconds
-
         Then container "postgresql1" pgconsul log contains messages in order within "60" seconds
         """
         psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired

--- a/tests/features/overloaded_primary.feature
+++ b/tests/features/overloaded_primary.feature
@@ -25,7 +25,7 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
                     allow_potential_data_loss: 'no'
                     primary_switch_checks: 1
                     min_failover_timeout: 120
-                    primary_unavailability_timeout: 2
+                    primary_unavailability_timeout: 10
                 commands:
                     generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
         """
@@ -161,75 +161,5 @@ Feature: Overloaded postgres (primary and replica) is not restarted by pgconsul
         Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
         And container "postgresql1" became a primary
         And "pgbouncer" is running in container "postgresql1"
-        And container "postgresql2" is a replica of container "postgresql1"
-        And container "postgresql3" is a replica of container "postgresql1"
-
-    @skipping_restart @skipping_restart_replica
-    Scenario: Overloaded replica is not restarted while systemctl reports it running using default pg_conn_failure_grace_period
-        # pg_conn_failure_grace_period is NOT set in config — verifies the default value (30.0s) is applied.
-        Given a "pgconsul" container common config
-        """
-            pgconsul.conf:
-                global:
-                    priority: 0
-                    use_replication_slots: 'yes'
-                    quorum_commit: 'yes'
-                primary:
-                    change_replication_type: 'yes'
-                    primary_switch_checks: 1
-                replica:
-                    allow_potential_data_loss: 'no'
-                    primary_switch_checks: 1
-                    min_failover_timeout: 120
-                    primary_unavailability_timeout: 2
-                commands:
-                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_with_slot.sh %m %p
-        """
-        Given a following cluster with "zookeeper" with replication slots
-        """
-            postgresql1:
-                role: primary
-            postgresql2:
-                role: replica
-                config:
-                    pgconsul.conf:
-                        global:
-                            priority: 2
-            postgresql3:
-                role: replica
-                config:
-                    pgconsul.conf:
-                        global:
-                            priority: 1
-        """
-        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
-        And container "postgresql2" is in quorum group
-        And container "postgresql3" is in quorum group
-        And container "postgresql2" is a replica of container "postgresql1"
-        And container "postgresql3" is a replica of container "postgresql1"
-        And "pgbouncer" is running in container "postgresql2"
-
-        When we remember postgresql start time in container "postgresql2"
-
-        # SIGSTOP simulates overload on replica: process alive (systemctl=running) but connection times out.
-        When we kill "postgres" in container "postgresql2" with signal "STOP"
-
-        # pg_conn_failure_grace_period=30s (default). 15s elapsed < 30s → Skipping.
-        When we wait "15.0" seconds
-
-        # Unfreeze postgres.
-        When we kill "postgres" in container "postgresql2" with signal "CONT"
-
-        Then container "postgresql2" pgconsul log contains messages in order within "60" seconds
-        """
-        psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: timeout expired
-        Connection timeout diagnostics: pg_status=0
-        Skipping.
-        """
-
-        # No failover: primary lock unchanged, replica not restarted.
-        And zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
-        And postgresql in container "postgresql2" was not restarted
-        And "pgbouncer" is running in container "postgresql2"
         And container "postgresql2" is a replica of container "postgresql1"
         And container "postgresql3" is a replica of container "postgresql1"

--- a/tests/steps/cluster.py
+++ b/tests/steps/cluster.py
@@ -1097,6 +1097,7 @@ def step_remember_pg_start_time(context, name):
 
 
 @then('postgresql in container "(?P<name>[a-zA-Z0-9_-]+)" was(?P<not_restarted>| not) restarted')
+@helpers.retry_on_assert
 def step_was_pg_restarted(context, name, not_restarted):
     not_restarted = not_restarted.strip()
     if not_restarted == '':

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+# encoding: utf-8
+"""
+Unit tests package
+"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+"""
+pytest conftest for unit tests that import src submodules directly.
+
+Stubs out heavy third-party dependencies (psycopg2, kazoo, etc.) so that
+src modules can be imported without the actual packages being installed.
+Also registers the project root on sys.path so that `import src.*` works.
+
+This file is loaded automatically by pytest before any test module in this
+directory, so individual test files do not need to repeat this bootstrap.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_ROOT = Path(__file__).parent.parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+for _mod_name in (
+    'psycopg2', 'psycopg2.extensions', 'psycopg2.sql',
+    'kazoo', 'kazoo.client', 'kazoo.exceptions',
+    'kazoo.handlers', 'kazoo.handlers.threading',
+    'kazoo.recipe', 'kazoo.recipe.lock', 'kazoo.security',
+    'lockfile', 'lockfile.pidlockfile', 'daemon',
+):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+if 'src' not in sys.modules:
+    _src_pkg = types.ModuleType('src')
+    _src_pkg.__path__ = [str(_ROOT / 'src')]
+    _src_pkg.__package__ = 'src'
+    sys.modules['src'] = _src_pkg

--- a/tests/unit/test_pg_conn_grace_period.py
+++ b/tests/unit/test_pg_conn_grace_period.py
@@ -1,11 +1,10 @@
 # encoding: utf-8
 from unittest.mock import patch
 
-
 from src.pg_conn_grace_period import PgConnGracePeriod
 
 
-def make(grace: float = 30.0) -> PgConnGracePeriod:
+def make(grace: int = 30) -> PgConnGracePeriod:
     return PgConnGracePeriod(grace)
 
 
@@ -14,8 +13,7 @@ def make(grace: float = 30.0) -> PgConnGracePeriod:
 # ---------------------------------------------------------------------------
 
 def test_negative_grace_period_falls_back_to_zero():
-    gp = PgConnGracePeriod(-5.0)
-    # after record_failure, process running, should act immediately
+    gp = PgConnGracePeriod(-5)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()
@@ -33,13 +31,12 @@ def test_reset_causes_should_act_true_without_failure():
 
 
 def test_reset_clears_failure_state():
-    gp = make(grace=60.0)
+    gp = make(grace=60)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()
         gp.reset()
         t.time.return_value = 1.0
-        # after reset, no failure context — acts normally
         assert gp.should_act(pg_running=True) is True
 
 
@@ -48,7 +45,7 @@ def test_reset_clears_failure_state():
 # ---------------------------------------------------------------------------
 
 def test_within_grace_pg_running_returns_false():
-    gp = make(grace=30.0)
+    gp = make(grace=30)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 100.0
         gp.record_failure()
@@ -57,7 +54,7 @@ def test_within_grace_pg_running_returns_false():
 
 
 def test_within_grace_pg_not_running_returns_true():
-    gp = make(grace=30.0)
+    gp = make(grace=30)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 100.0
         gp.record_failure()
@@ -70,7 +67,7 @@ def test_within_grace_pg_not_running_returns_true():
 # ---------------------------------------------------------------------------
 
 def test_expired_grace_pg_running_returns_true():
-    gp = make(grace=30.0)
+    gp = make(grace=30)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()
@@ -79,7 +76,7 @@ def test_expired_grace_pg_running_returns_true():
 
 
 def test_exactly_at_grace_boundary_returns_true():
-    gp = make(grace=30.0)
+    gp = make(grace=30)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()
@@ -92,7 +89,7 @@ def test_exactly_at_grace_boundary_returns_true():
 # ---------------------------------------------------------------------------
 
 def test_record_failure_keeps_first_timestamp():
-    gp = make(grace=30.0)
+    gp = make(grace=30)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()
@@ -107,7 +104,7 @@ def test_record_failure_keeps_first_timestamp():
 # ---------------------------------------------------------------------------
 
 def test_zero_grace_acts_immediately():
-    gp = make(grace=0.0)
+    gp = make(grace=0)
     with patch('src.pg_conn_grace_period.time') as t:
         t.time.return_value = 0.0
         gp.record_failure()

--- a/tests/unit/test_pg_conn_grace_period.py
+++ b/tests/unit/test_pg_conn_grace_period.py
@@ -1,0 +1,115 @@
+# encoding: utf-8
+from unittest.mock import patch
+
+
+from src.pg_conn_grace_period import PgConnGracePeriod
+
+
+def make(grace: float = 30.0) -> PgConnGracePeriod:
+    return PgConnGracePeriod(grace)
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+def test_negative_grace_period_falls_back_to_zero():
+    gp = PgConnGracePeriod(-5.0)
+    # after record_failure, process running, should act immediately
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        t.time.return_value = 0.0
+        assert gp.should_act(pg_running=True) is True
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+def test_reset_causes_should_act_true_without_failure():
+    gp = make()
+    assert gp.should_act(pg_running=True) is True
+
+
+def test_reset_clears_failure_state():
+    gp = make(grace=60.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        gp.reset()
+        t.time.return_value = 1.0
+        # after reset, no failure context — acts normally
+        assert gp.should_act(pg_running=True) is True
+
+
+# ---------------------------------------------------------------------------
+# within grace period
+# ---------------------------------------------------------------------------
+
+def test_within_grace_pg_running_returns_false():
+    gp = make(grace=30.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 100.0
+        gp.record_failure()
+        t.time.return_value = 115.0  # 15s elapsed < 30s grace
+        assert gp.should_act(pg_running=True) is False
+
+
+def test_within_grace_pg_not_running_returns_true():
+    gp = make(grace=30.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 100.0
+        gp.record_failure()
+        t.time.return_value = 110.0  # still within grace but process dead
+        assert gp.should_act(pg_running=False) is True
+
+
+# ---------------------------------------------------------------------------
+# grace period expired
+# ---------------------------------------------------------------------------
+
+def test_expired_grace_pg_running_returns_true():
+    gp = make(grace=30.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        t.time.return_value = 31.0  # 31s elapsed > 30s grace
+        assert gp.should_act(pg_running=True) is True
+
+
+def test_exactly_at_grace_boundary_returns_true():
+    gp = make(grace=30.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        t.time.return_value = 30.0  # elapsed == grace: not strictly less
+        assert gp.should_act(pg_running=True) is True
+
+
+# ---------------------------------------------------------------------------
+# record_failure idempotency
+# ---------------------------------------------------------------------------
+
+def test_record_failure_keeps_first_timestamp():
+    gp = make(grace=30.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        t.time.return_value = 5.0
+        gp.record_failure()   # second call must not update timestamp
+        t.time.return_value = 20.0  # 20s from first failure, within grace
+        assert gp.should_act(pg_running=True) is False
+
+
+# ---------------------------------------------------------------------------
+# zero grace period
+# ---------------------------------------------------------------------------
+
+def test_zero_grace_acts_immediately():
+    gp = make(grace=0.0)
+    with patch('src.pg_conn_grace_period.time') as t:
+        t.time.return_value = 0.0
+        gp.record_failure()
+        t.time.return_value = 0.0
+        assert gp.should_act(pg_running=True) is True


### PR DESCRIPTION
Add **pg_conn_failure_grace_period** (default 0s): when a connection
timeout occurs but systemctl reports postgres as running, pgconsul
now waits out the grace period before forcing a restart. Also adds
exponential connect_timeout backoff (1→2→4→8→10s) and diagnostics
logging on timeout (pg_status, loadavg, cpu_count, PSI metrics).
