### PR TITLE
MDB-45407: cascade replica can switchover with stale recovery.conf

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -118,7 +118,7 @@ def extract_host(conninfo):
     """
     if not conninfo:
         return None
-    match = re.search(r'host=([\w\-\._]*)', conninfo)
+    match = re.search(r'host=([\w.-]+)', conninfo)
     if match:
         return match.group(1)
     return None

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -112,6 +112,18 @@ def app_name_from_fqdn(fqdn):
     return fqdn.replace('.', '_').replace('-', '_')
 
 
+def extract_host(conninfo):
+    """
+    Extract host= FQDN from a libpq conninfo string. Note: IPv6 literals are not supported.
+    """
+    if not conninfo:
+        return None
+    match = re.search(r'host=([\w\-\._]*)', conninfo)
+    if match:
+        return match.group(1)
+    return None
+
+
 def get_hostname():
     """
     return fqdn of local machine

--- a/src/main.py
+++ b/src/main.py
@@ -1890,7 +1890,7 @@ class pgconsul(object):
         and False otherwise
         """
         if not primary:
-            primary = self.db.recovery_conf('get_primary')
+            primary = self.db.get_primary_fqdn()
             if not primary:
                 return False
         append = self.config.get('global', 'append_primary_conn_string')

--- a/src/pg.py
+++ b/src/pg.py
@@ -244,7 +244,7 @@ class Postgres(object):
                 data['replication_state'] = self.get_replication_state()
                 data['sessions_ratio'] = self.get_sessions_ratio()
             elif data['role'] == 'replica':
-                data['primary_fqdn'] = self.recovery_conf('get_primary')
+                data['primary_fqdn'] = self.get_primary_fqdn()
                 data['replics_info'] = self.get_replics_info('replica')
 
             #
@@ -468,6 +468,20 @@ class Postgres(object):
                 pg_last_wal_replay_lsn(),
                 '{diff_from}')::bigint"""
         return self._exec_query(query).fetchone()[0]
+
+    @helpers.return_none_on_error
+    def _get_primary_fqdn_from_db(self) -> str | None:
+        # Primary FQDN from runtime primary_conninfo; more reliable than stale recovery.conf
+        value = self._get_param_value('primary_conninfo')
+        if not value:
+            return None
+        if match := re.search(r'host=([\w\-\._]*)', value):
+            return match.group(0).split('=')[-1]
+        return None
+
+    def get_primary_fqdn(self) -> str | None:
+        # Single source for primary FQDN: runtime takes priority, recovery.conf as fallback
+        return self._get_primary_fqdn_from_db() or self.recovery_conf('get_primary')
 
     def recovery_conf(self, action, primary_host=None) -> str | None:
         """

--- a/src/pg.py
+++ b/src/pg.py
@@ -468,14 +468,15 @@ class Postgres(object):
                 '{diff_from}')::bigint"""
         return self._exec_query(query).fetchone()[0]
 
-    @helpers.return_none_on_error
-    def _get_primary_fqdn_from_db(self) -> str | None:
-        # Primary FQDN from runtime primary_conninfo; more reliable than stale recovery.conf
-        return helpers.extract_host(self._get_param_value('primary_conninfo'))
-
     def get_primary_fqdn(self) -> str | None:
-        # Single source for primary FQDN: runtime takes priority, recovery.conf as fallback
-        return self._get_primary_fqdn_from_db() or self.recovery_conf('get_primary')
+        # Single source for primary FQDN: runtime primary_conninfo takes priority
+        # (more reliable than stale recovery.conf), recovery.conf is used as a fallback.
+        try:
+            primary_fqdn = helpers.extract_host(self._get_param_value('primary_conninfo'))
+        except Exception as exc:
+            logging.debug('Could not read runtime primary_conninfo, will fall back to recovery.conf: %s', exc)
+            primary_fqdn = None
+        return primary_fqdn or self.recovery_conf('get_primary')
 
     def recovery_conf(self, action, primary_host=None) -> str | None:
         """

--- a/src/pg.py
+++ b/src/pg.py
@@ -9,7 +9,6 @@ import json
 import logging
 from functools import partial
 import os
-import re
 import signal
 import socket
 import time
@@ -472,12 +471,7 @@ class Postgres(object):
     @helpers.return_none_on_error
     def _get_primary_fqdn_from_db(self) -> str | None:
         # Primary FQDN from runtime primary_conninfo; more reliable than stale recovery.conf
-        value = self._get_param_value('primary_conninfo')
-        if not value:
-            return None
-        if match := re.search(r'host=([\w\-\._]*)', value):
-            return match.group(0).split('=')[-1]
-        return None
+        return helpers.extract_host(self._get_param_value('primary_conninfo'))
 
     def get_primary_fqdn(self) -> str | None:
         # Single source for primary FQDN: runtime takes priority, recovery.conf as fallback
@@ -502,9 +496,7 @@ class Postgres(object):
                 with open(recovery_filepath, 'r') as recovery_file:
                     for i in recovery_file.read().split('\n'):
                         if 'primary_conninfo' in i:
-                            if match := re.search(r'host=([\w\-\._]*)', i):
-                                return match.group(0).split('=')[-1]
-                            return None
+                            return helpers.extract_host(i)
             return None
 
     def promote(self) -> bool:

--- a/tests/features/cascade.feature
+++ b/tests/features/cascade.feature
@@ -374,7 +374,6 @@ Feature: Check not HA hosts
                     primary_unavailability_timeout: 1
                     primary_switch_checks: 1
                     min_failover_timeout: 1
-                    primary_unavailability_timeout: 2
                     recovery_timeout: 30
                 commands:
                     generate_recovery_conf: /usr/local/bin/gen_rec_conf_without_slot.sh %m %p

--- a/tests/features/cascade.feature
+++ b/tests/features/cascade.feature
@@ -356,6 +356,67 @@ Feature: Check not HA hosts
         | zookeeper | zookeeper1 |
 
 
+    # Cascade replica must accept switchover when on-disk recovery.conf is stale.
+    @auto_stream_from_bug @switchover
+    Scenario: Cascade replica accepts switchover with stale recovery.conf
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: 'yes'
+                    quorum_commit: 'yes'
+                primary:
+                    change_replication_type: 'yes'
+                    primary_switch_checks: 1
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_unavailability_timeout: 1
+                    primary_switch_checks: 1
+                    min_failover_timeout: 1
+                    primary_unavailability_timeout: 2
+                    recovery_timeout: 30
+                commands:
+                    generate_recovery_conf: /usr/local/bin/gen_rec_conf_without_slot.sh %m %p
+        """
+        Given a following cluster with "zookeeper" without replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+            postgresql3:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            stream_from: pgconsul_postgresql1_1.pgconsul_pgconsul_net
+                stream_from: postgresql1
+        """
+
+        Then zookeeper "zookeeper1" has holder "pgconsul_postgresql1_1.pgconsul_pgconsul_net" for lock "/pgconsul/postgresql/leader"
+        And container "postgresql2" is in quorum group
+        And container "postgresql3" is a replica of container "postgresql1"
+
+        # Make recovery.conf stale (runtime primary_conninfo still points to postgresql1).
+        When we run following command on host "postgresql3"
+        """
+        sh -c 'sed -i "s/host=[^ ]*/host=pgconsul_postgresql2_1.pgconsul_pgconsul_net/" /var/lib/postgresql/*/main/conf.d/recovery.conf'
+        """
+
+        # Switchover postgresql1 -> postgresql2.
+        When we lock "/pgconsul/postgresql/switchover/lock" in zookeeper "zookeeper1"
+        And we set value "{'hostname': 'pgconsul_postgresql1_1.pgconsul_pgconsul_net', 'timeline': 1, 'destination': 'pgconsul_postgresql2_1.pgconsul_pgconsul_net'}" for key "/pgconsul/postgresql/switchover/master" in zookeeper "zookeeper1"
+        And we set value "scheduled" for key "/pgconsul/postgresql/switchover/state" in zookeeper "zookeeper1"
+        And we release lock "/pgconsul/postgresql/switchover/lock" in zookeeper "zookeeper1"
+
+        # Must succeed despite stale recovery.conf.
+        Then container "postgresql2" became a primary
+        And container "postgresql1" is a replica of container "postgresql2"
+        And container "postgresql3" is a replica of container "postgresql1"
+        And postgresql in container "postgresql3" was not rewinded
+
+
     Scenario Outline: Replication slots created automatically
         Given a "pgconsul" container common config
         """


### PR DESCRIPTION
fix(replication): use runtime primary_conninfo for primary FQDN

Determine the current primary FQDN from PostgreSQL runtime
(SHOW primary_conninfo) instead of the on-disk recovery.conf, which
may be stale and caused cascade replicas to ignore switchover. The
recovery.conf value is kept only as a fallback.