### PR TITLE
MDB-41956: split Zookeeper into ZkClient and high-level facade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 
 ## Important Conventions
 
+### Comments
+
+- All added comments must be concise
+
 ### Working with ZooKeeper
 
 - All ZK paths are defined as constants in the `Zookeeper` class (`src/zk.py`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 
 ### Comments
 
-- All added comments must be concise
+- All added comments must be brief and in English
 
 ### Working with ZooKeeper
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,15 @@ Every second, `pgconsul` executes `run_iteration()`:
 
 ### Unit Tests (pytest)
 
+Unit tests are located in `tests/unit/` directory.
+
 ```bash
-pytest tests/test_*.py -v
-pytest tests/test_*.py --cov=src --cov-report=html --cov-report=term
+# Run all unit tests
+make unit_test
+
+# Or run directly with pytest
+pytest tests/unit/ -v
+pytest tests/unit/ --cov=src --cov-report=html --cov-report=term
 ```
 
 ### Integration BDD Tests (behave)
@@ -171,8 +177,8 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 
 ### Adding a Unit Test
 
-- Test files: `tests/test_*.py`
-- Run: `pytest tests/test_*.py -v`
+- Test files: `tests/unit/test_*.py`
+- Run: `pytest tests/unit/ -v` or `make unit_test`
 - Uses standard `pytest`; mocking via `unittest.mock`
 
 ### Adding a BDD Test
@@ -186,4 +192,4 @@ Full reference: [`docs/CONFIG.md`](docs/CONFIG.md)
 - Core logic: [`src/replication_manager.py`](src/replication_manager.py)
 - Configuration: [`src/replication_manager_factory.py`](src/replication_manager_factory.py)
 - SSN management: [`src/ssn_manager.py`](src/ssn_manager.py)
-- Tests: `tests/test_replication_manager_*.py`, `tests/test_ssn_manager.py`
+- Tests: `tests/unit/test_replication_manager_*.py`, `tests/unit/test_ssn_manager.py`

--- a/docs/ZK.md
+++ b/docs/ZK.md
@@ -62,3 +62,39 @@ This lock is taken by the replica (or former primary) when switching to a new pr
 
 * `SWITCHOVER_LOCK_PATH` = `switchover/lock`
 This lock is taken by the CLI at the time of creating/clearing information about switchover in ZK. This lock is not involved in the primary switching process itself.
+
+## Two-layer architecture
+
+The ZooKeeper integration is split into two layers:
+
+### Transport layer — `ZkClient` (`src/zk_client.py`)
+
+Wraps `KazooClient` and provides raw data operations with path-prefix support.
+All methods raise **domain exceptions** instead of raw Kazoo exceptions:
+
+| Exception | Meaning |
+|-----------|---------|
+| `ZkClientError` | General ZK connection or command error |
+| `ZkNoNodeError` | Node does not exist (subclass of `ZkClientError`) |
+| `ZkSessionExpiredError` | ZK session expired (subclass of `ZkClientError`) |
+| `ZkLockTimeout` | Lock acquire timed out |
+| `ZkConnectionClosedError` | Connection was explicitly closed |
+
+`ZkClient` handles reconnection with exponential backoff and jitter via `reconnect()`.
+Lock lifecycle (drop stale locks, re-init primary lock) is owned by the layer above.
+
+### Business layer — `Zookeeper` (`src/zk.py`)
+
+Wraps `ZkClient` and provides domain-oriented methods.
+
+**Error-handling contract:**
+
+* `get()` — raises `ZookeeperException` on ZK errors (callers decide whether to propagate or swallow).
+* `noexcept_get()` — swallows all exceptions, returns `None`.
+* `write()` — raises `ZookeeperException` on ZK errors.
+* `noexcept_write()` — swallows all exceptions, returns `False`.
+* `delete()` — catches `ZkClientError`, logs it, returns `False`; returns `True` on success or when node is absent.
+* `delete_*()` methods — delegate to `delete()` and therefore always return `bool` (never raise `ZkClientError`).
+* High-level `write_*()` methods — catch `Exception`, log it, return `False`.
+
+This means callers of `Zookeeper` methods **never receive raw Kazoo or `ZkClientError` exceptions** — all errors are either converted to `ZookeeperException` (for `get`/`write`) or absorbed and logged (for `noexcept_*` and `delete`/`write_*` variants).

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,8 +12,8 @@ import socket
 import sys
 import logging
 
-from . import read_config, init_logging, zk as zookeeper
-from .zk import create_zk
+from . import read_config, init_logging
+from .zk import Zookeeper
 from . import helpers
 from . import utils
 from .exceptions import SwitchoverException, FailoverException, ResetException
@@ -56,46 +56,45 @@ def entry():
         sys.exit(1)
 
 
-def maintenance_enabled(zk):
+def maintenance_enabled(zk: Zookeeper):
     """
     Returns True if all hosts confirmed that maintenance is enabled.
     """
     for host in zk.get_alive_hosts():
-        if zk.get(zk.get_host_maintenance_path(host)) != 'enable':
+        if zk.get_host_maintenance_status(host) != 'enable':
             return False
     return True
 
 
-def maintenance_disabled(zk):
+def maintenance_disabled(zk: Zookeeper):
     """
     Common maintenance node should be deleted
     """
-    return zk.get(zk.MAINTENANCE_PATH) is None
+    return zk.get_maintenance_status() is None
 
 
-def _wait_maintenance_enabled(zk, timeout):
+def _wait_maintenance_enabled(zk: Zookeeper, timeout):
     is_maintenance_enabled = functools.partial(maintenance_enabled, zk)
     if not helpers.await_for(is_maintenance_enabled, timeout, 'enabling maintenance mode'):
         # Return cluster to last state, i.e. disable maintenance.
-        zk.write(zk.MAINTENANCE_PATH, 'disable')
+        zk.write_maintenance_status('disable')
         raise TimeoutError
     logging.info('Success')
 
 
-def _wait_maintenance_disabled(zk, timeout):
+def _wait_maintenance_disabled(zk: Zookeeper, timeout):
     is_maintenance_disabled = functools.partial(maintenance_disabled, zk)
     if not helpers.await_for(is_maintenance_disabled, timeout, 'disabling maintenance mode'):
         # Return cluster to the last state, i.e. enable maintenance.
         # There is obvious race condition between time when primary deletes this node
         # and we write value here. We assume that big timeout will help us here.
-        zk.write(zk.MAINTENANCE_PATH, 'enable')
+        zk.write_maintenance_status('enable')
         raise TimeoutError
     logging.info('Success')
 
 
-def enable_maintenance(zk, timeout, wait_all):
-    zk.ensure_path(zk.MAINTENANCE_PATH)
-    zk.noexcept_write(zk.MAINTENANCE_PATH, 'enable', need_lock=False)
+def enable_maintenance(zk: Zookeeper, timeout, wait_all):
+    zk.write_maintenance_status('enable')
     if wait_all:
         _wait_maintenance_enabled(zk, timeout)
 
@@ -104,15 +103,15 @@ def maintenance(opts, conf):
     """
     Enable or disable maintenance mode.
     """
-    zk = zookeeper.Zookeeper(config=conf)
+    zk = Zookeeper(config=conf)
     if opts.mode == 'enable':
         enable_maintenance(zk, opts.timeout, opts.wait_all)
     elif opts.mode == 'disable':
-        zk.write(zk.MAINTENANCE_PATH, 'disable', need_lock=False)
+        zk.write_maintenance_status('disable')
         if opts.wait_all:
             _wait_maintenance_disabled(zk, opts.timeout)
     elif opts.mode == 'show':
-        val = zk.get(zk.MAINTENANCE_PATH) or 'disable'
+        val = zk.get_maintenance_status() or 'disable'
         print('{val}d'.format(val=val))
 
 
@@ -125,17 +124,18 @@ def initzk(opts, conf):
     and can fail if zk didn't response for 1 second
     """
     conf.set('global', 'iteration_timeout', 5)
-    zk = zookeeper.Zookeeper(config=conf)
+    zk = Zookeeper(config=conf)
     for host in opts.members:
-        path = '{members}/{host}'.format(members=zk.MEMBERS_PATH, host=host)
         if opts.test:
+            path = zk.get_member_path(host)
             logging.debug(f'Fetching path "{path}"...')
-            if not zk.exists_path(path):
+            if not zk.member_exists(host):
                 logging.debug(f'Path "{path}" not found in ZK, initialization has not been performed earlier')
                 sys.exit(2)
         else:
+            path = zk.get_member_path(host)
             logging.debug('creating "%s"...', path)
-            if not zk.ensure_path(path):
+            if not zk.ensure_member(host):
                 raise RuntimeError(f'Could not create path "{path}" in ZK')
     if opts.test:
         logging.debug('Initialization for all fqdns has been performed earlier')
@@ -191,9 +191,9 @@ def reset_all(opts, conf):
     Resets all nodes in ZK, except for zk.MEMBERS_PATH
     """
     conf.set('global', 'iteration_timeout', 5)
-    zk = zookeeper.Zookeeper(config=conf)
+    zk = Zookeeper(config=conf)
     logging.debug("resetting all ZK nodes")
-    all_nodes = zk.get_children("")
+    all_nodes = zk.get_root_children()
     if all_nodes is None:
         logging.error("Could not get nodes to reset")
         all_nodes = []
@@ -228,7 +228,7 @@ def show_info(opts, conf):
 
 
 def _show_info(opts, conf):
-    zk = zookeeper.Zookeeper(config=conf)
+    zk = Zookeeper(config=conf)
     zk_state = zk.get_state()
     zk_state['primary'] = zk_state.pop('lock_holder')  # rename field name to avoid misunderstandings
     if zk_state[zk.MAINTENANCE_PATH]['status'] is None:

--- a/src/cli.py
+++ b/src/cli.py
@@ -13,6 +13,7 @@ import sys
 import logging
 
 from . import read_config, init_logging, zk as zookeeper
+from .zk import create_zk
 from . import helpers
 from . import utils
 from .exceptions import SwitchoverException, FailoverException, ResetException

--- a/src/cli.py
+++ b/src/cli.py
@@ -103,16 +103,16 @@ def maintenance(opts, conf):
     """
     Enable or disable maintenance mode.
     """
-    zk = Zookeeper(config=conf)
-    if opts.mode == 'enable':
-        enable_maintenance(zk, opts.timeout, opts.wait_all)
-    elif opts.mode == 'disable':
-        zk.write_maintenance_status('disable')
-        if opts.wait_all:
-            _wait_maintenance_disabled(zk, opts.timeout)
-    elif opts.mode == 'show':
-        val = zk.get_maintenance_status() or 'disable'
-        print('{val}d'.format(val=val))
+    with create_zk(config=conf) as zk:
+        if opts.mode == 'enable':
+            enable_maintenance(zk, opts.timeout, opts.wait_all)
+        elif opts.mode == 'disable':
+            zk.write_maintenance_status('disable')
+            if opts.wait_all:
+                _wait_maintenance_disabled(zk, opts.timeout)
+        elif opts.mode == 'show':
+            val = zk.get_maintenance_status() or 'disable'
+            print('{val}d'.format(val=val))
 
 
 def initzk(opts, conf):
@@ -133,22 +133,23 @@ def initzk(opts, conf):
             sys.exit(2)
         path = f'{Zookeeper.MEMBERS_PATH}/{opts.members[0]}'
         raise RuntimeError(f'Could not create path "{path}" in ZK') from exc
-    for host in opts.members:
+    with zk:
+        for host in opts.members:
+            if opts.test:
+                path = zk.get_member_path(host)
+                logging.debug(f'Fetching path "{path}"...')
+                if not zk.member_exists(host):
+                    logging.debug(f'Path "{path}" not found in ZK, initialization has not been performed earlier')
+                    sys.exit(2)
+            else:
+                path = zk.get_member_path(host)
+                logging.debug('creating "%s"...', path)
+                if not zk.ensure_member(host):
+                    raise RuntimeError(f'Could not create path "{path}" in ZK')
         if opts.test:
-            path = zk.get_member_path(host)
-            logging.debug(f'Fetching path "{path}"...')
-            if not zk.member_exists(host):
-                logging.debug(f'Path "{path}" not found in ZK, initialization has not been performed earlier')
-                sys.exit(2)
+            logging.debug('Initialization for all fqdns has been performed earlier')
         else:
-            path = zk.get_member_path(host)
-            logging.debug('creating "%s"...', path)
-            if not zk.ensure_member(host):
-                raise RuntimeError(f'Could not create path "{path}" in ZK')
-    if opts.test:
-        logging.debug('Initialization for all fqdns has been performed earlier')
-    else:
-        logging.debug('ZK structures are initialized')
+            logging.debug('ZK structures are initialized')
 
 
 def switchover(opts, conf):
@@ -199,28 +200,28 @@ def reset_all(opts, conf):
     Resets all nodes in ZK, except for zk.MEMBERS_PATH
     """
     conf.set('global', 'iteration_timeout', 5)
-    zk = Zookeeper(config=conf)
-    logging.debug("resetting all ZK nodes")
-    all_nodes = zk.get_root_children()
-    if all_nodes is None:
-        logging.error("Could not get nodes to reset")
-        all_nodes = []
-    nodes_to_delete = [x for x in all_nodes if x not in (zk.MEMBERS_PATH, zk.MAINTENANCE_PATH)] + [zk.MAINTENANCE_PATH]
-    if not opts.force:
-        prompt = f'Nodes to delete: {", ".join(nodes_to_delete)}\n' \
-                 f'This is a potentially dangerous action. Proceed [y/n]?\n'
-        ans = input(prompt)
-        if ans == 'n':
-            return
-        elif ans != 'y':
-            print('Incorrect value, please type "y" or "n"')
-            return
-    enable_maintenance(zk, opts.timeout, True)
-    for node in nodes_to_delete:
-        logging.debug(f'resetting path "{node}"')
-        if not zk.delete(node, recursive=True):
-            raise ResetException(f'Could not reset node "{node}" in ZK')
-    logging.debug("ZK structures are reset")
+    with create_zk(config=conf) as zk:
+        logging.debug("resetting all ZK nodes")
+        all_nodes = zk.get_root_children()
+        if all_nodes is None:
+            logging.error("Could not get nodes to reset")
+            all_nodes = []
+        nodes_to_delete = [x for x in all_nodes if x not in (zk.MEMBERS_PATH, zk.MAINTENANCE_PATH)] + [zk.MAINTENANCE_PATH]
+        if not opts.force:
+            prompt = f'Nodes to delete: {", ".join(nodes_to_delete)}\n' \
+                     f'This is a potentially dangerous action. Proceed [y/n]?\n'
+            ans = input(prompt)
+            if ans == 'n':
+                return
+            elif ans != 'y':
+                print('Incorrect value, please type "y" or "n"')
+                return
+        enable_maintenance(zk, opts.timeout, True)
+        for node in nodes_to_delete:
+            logging.debug(f'resetting path "{node}"')
+            if not zk.delete(node, recursive=True):
+                raise ResetException(f'Could not reset node "{node}" in ZK')
+        logging.debug("ZK structures are reset")
 
 
 def show_info(opts, conf):
@@ -236,18 +237,20 @@ def show_info(opts, conf):
 
 
 def _show_info(opts, conf):
-    zk = Zookeeper(config=conf)
-    zk_state = zk.get_state()
-    zk_state['primary'] = zk_state.pop('lock_holder')  # rename field name to avoid misunderstandings
-    if zk_state[zk.MAINTENANCE_PATH]['status'] is None:
-        zk_state[zk.MAINTENANCE_PATH] = None
+    with create_zk(config=conf) as zk:
+        zk_state = zk.get_state()
+        zk_state['primary'] = zk_state.pop('lock_holder')  # rename field name to avoid misunderstandings
+        maintenance_path = zk.MAINTENANCE_PATH
+        last_failover_path = zk.LAST_FAILOVER_TIME_PATH
+    if zk_state[maintenance_path]['status'] is None:
+        zk_state[maintenance_path] = None
 
     if opts.short:
         return {
             'alive': zk_state['alive'],
             'primary': zk_state['primary'],
-            'last_failover_time': zk_state[zk.LAST_FAILOVER_TIME_PATH],
-            'maintenance': zk_state[zk.MAINTENANCE_PATH],
+            'last_failover_time': zk_state[last_failover_path],
+            'maintenance': zk_state[maintenance_path],
             'replics_info': _short_replica_infos(zk_state['replics_info']),
         }
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -13,7 +13,7 @@ import sys
 import logging
 
 from . import read_config, init_logging
-from .zk import Zookeeper
+from .zk import create_zk, Zookeeper
 from . import helpers
 from . import utils
 from .exceptions import SwitchoverException, FailoverException, ResetException
@@ -124,7 +124,15 @@ def initzk(opts, conf):
     and can fail if zk didn't response for 1 second
     """
     conf.set('global', 'iteration_timeout', 5)
-    zk = Zookeeper(config=conf)
+    try:
+        zk: Zookeeper = create_zk(config=conf,)
+    except Exception as exc:
+        # ZK is unreachable: connection failure is indistinguishable from "not initialized".
+        if opts.test:
+            logging.exception('Could not connect to ZK (KazooTimeoutError)')
+            sys.exit(2)
+        path = f'{Zookeeper.MEMBERS_PATH}/{opts.members[0]}'
+        raise RuntimeError(f'Could not create path "{path}" in ZK') from exc
     for host in opts.members:
         if opts.test:
             path = zk.get_member_path(host)

--- a/src/failover_election.py
+++ b/src/failover_election.py
@@ -69,15 +69,7 @@ class FailoverElection(object):
         self._quorum_size = quorum_size
 
     def _get_host_vote(self, hostname):
-        lsn = self._zk.get(self._zk.get_election_vote_path(hostname) + '/lsn', preproc=int, debug=True)
-        if lsn is None:
-            logging.error("Failed to get '%s' lsn for elections.", hostname)
-            return None
-        priority = self._zk.get(self._zk.get_election_vote_path(hostname) + '/prio', preproc=int, debug=True)
-        if priority is None:
-            logging.error("Failed to get '%s' priority for elections.", hostname)
-            return None
-        return lsn, priority
+        return self._zk.get_election_host_vote(hostname)
 
     def _collect_votes(self):
         votes = {}
@@ -112,11 +104,7 @@ class FailoverElection(object):
 
     def _vote_in_election(self):
         logging.debug(f"Going to vote in election: lsn {self._host_lsn}, prio {self._host_priority}")
-        if not self._zk.ensure_path(self._zk.get_election_vote_path()):
-            raise VoteFailError
-        if not self._zk.write(self._zk.get_election_vote_path() + '/lsn', self._host_lsn, need_lock=False):
-            raise VoteFailError
-        if not self._zk.write(self._zk.get_election_vote_path() + '/prio', self._host_priority, need_lock=False):
+        if not self._zk.write_election_vote(self._host_lsn, self._host_priority):
             raise VoteFailError
         logging.info("Successfully voted")
 
@@ -135,12 +123,12 @@ class FailoverElection(object):
 
     def _cleanup_votes(self):
         for replica in self._zk.get_ha_hosts():
-            if not self._zk.delete(self._zk.get_election_vote_path(replica), recursive=True):
+            if not self._zk.delete_election_vote(replica):
                 raise CleanupError
 
     def _await_election_status(self, status):
         if not helpers.await_for(
-            lambda: self._zk.get(self._zk.ELECTION_STATUS_PATH) == status, self._timeout, f'election status {status}'
+            lambda: self._zk.get_election_status() == status, self._timeout, f'election status {status}'
         ):
             raise ElectionTimeout
 
@@ -151,7 +139,7 @@ class FailoverElection(object):
 
     def _write_election_status(self, status):
         logging.debug('Changing election status to: %s', status)
-        if not self._zk.write(self._zk.ELECTION_STATUS_PATH, status, need_lock=False):
+        if not self._zk.write_election_status(status):
             raise StatusChangeError
 
     def _participate_in_election(self):
@@ -166,7 +154,7 @@ class FailoverElection(object):
         self._await_election_status(STATUS_REGISTRATION)
         self._vote_in_election()
         self._await_election_status(STATUS_DONE)
-        if self._zk.get(self._zk.ELECTION_WINNER_PATH) == helpers.get_hostname():
+        if self._zk.get_election_winner() == helpers.get_hostname():
             if not self._zk.try_acquire_lock(self._zk.PRIMARY_LOCK_PATH, timeout=self._timeout):
                 return False
             if not self._await_lock_holder_fits(
@@ -175,7 +163,7 @@ class FailoverElection(object):
                 f'lock {self._zk.ELECTION_MANAGER_LOCK_PATH} is empty',
             ):
                 raise ElectionTimeout
-            if self._zk.get(self._zk.ELECTION_STATUS_PATH) == STATUS_FAILED:
+            if self._zk.get_election_status() == STATUS_FAILED:
                 self._zk.release_lock(self._zk.PRIMARY_LOCK_PATH)
                 return False
             return True
@@ -200,7 +188,7 @@ class FailoverElection(object):
             return False
         winner_host = FailoverElection._determine_election_winner(votes)
         logging.info('Elected %s', winner_host)
-        if not self._zk.write(self._zk.ELECTION_WINNER_PATH, winner_host, need_lock=False):
+        if not self._zk.write_election_winner(winner_host):
             return False
         self._write_election_status(STATUS_DONE)
         if winner_host == helpers.get_hostname():

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -138,6 +138,13 @@ def get_hostname():
     return socket.getfqdn()
 
 
+def get_host_path(path, hostname=None):
+    """Substitute hostname into a ZK path template (containing %s)."""
+    if hostname is None:
+        hostname = get_hostname()
+    return path % hostname
+
+
 def backup_dir(src, dst):
     """
     This function is basically 'rsync --delete -a <src> <dst>'

--- a/src/main.py
+++ b/src/main.py
@@ -1541,10 +1541,6 @@ class pgconsul(object):
         if last_failover_ts is None:
             logging.warning('There was no last failover ts in ZK. Skipping this check.')
             last_failover_ts = 0.0
-
-        if last_failover_ts is None:
-            logging.warning('There was no last failover ts in ZK. Skipping this check.')
-            last_failover_ts = 0.0
         diff = time.time() - last_failover_ts
         if not helpers.check_last_failover_time(last_failover_ts, self.config):
             logging.info('Last time failover has been done %f seconds ago. Not doing anything.', diff)
@@ -1588,7 +1584,7 @@ class pgconsul(object):
             logging.info("Host is still replaying WAL, so it can't be promoted.")
             return False
 
-        replica_infos = self.zk.noexcept_get(self.zk.REPLICS_INFO_PATH, preproc=json.loads)
+        replica_infos = self.zk.noexcept_get_replics_info()
         if replica_infos is None:
             logging.error('Unable to get replics info from ZK.')
             return False

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,6 @@ Main module. pgconsul class defined here.
 
 import atexit
 import functools
-import json
 import logging
 import os
 import random
@@ -48,7 +47,7 @@ class pgconsul(object):
         random.seed(os.urandom(16))
 
         self.db = Postgres(config=self._postgres_config(), cmd_manager=self._cmd_manager)
-        self.zk = create_zk(config=self.config)
+        self.zk: Zookeeper = create_zk(config=self.config)
         self.startup_checks()
 
         register_sigterm_handler()
@@ -203,15 +202,13 @@ class pgconsul(object):
         if not self._replication_manager.init_zk():
             return False
 
-        if self.config.getboolean('global', 'update_prio_in_zk') or \
-            helpers.get_hostname() not in self.zk.get_children(self.zk.MEMBERS_PATH):
-            if not self.zk.ensure_path(self.zk.get_host_prio_path()):
-                return False
-            if not self.zk.noexcept_write(self.zk.get_host_prio_path(), my_prio, need_lock=False):
+        members = self.zk.get_members() or []
+        if self.config.getboolean('global', 'update_prio_in_zk') or helpers.get_hostname() not in members:
+            if not self.zk.write_host_prio(my_prio):
                 return False
 
         # clear path created by mistake
-        self.zk.delete(self.zk.TIMINGS_PATH)
+        self.zk.delete_legacy_timings_path()
 
         return True
 
@@ -381,10 +378,10 @@ class pgconsul(object):
         # that our node is being removed.
         # No point in updating all_hosts
         # in this case
-        all_hosts = self.zk.get_children(self.zk.MEMBERS_PATH)
-        prio = self.zk.noexcept_get(self.zk.get_host_prio_path())
+        all_hosts = self.zk.get_members()
+        prio = self.zk.get_host_prio()
         if role and all_hosts and not prio:
-            if not self.zk.noexcept_write(self.zk.get_host_prio_path(), my_prio, need_lock=False):
+            if not self.zk.write_host_prio(my_prio):
                 logging.warning('Could not write priority to ZK')
 
         self.finish_iteration(timer)
@@ -432,7 +429,7 @@ class pgconsul(object):
         my_hostname = helpers.get_hostname()
         try:
             stream_from = self.config.get('global', 'stream_from')
-            last_op = self.zk.get('%s/%s/op' % (self.zk.MEMBERS_PATH, my_hostname))
+            last_op = self.zk.get_host_op(my_hostname)
             # If we were promoting or rewinding
             # and failed we should not acquire lock
             if self.is_op_destructive(last_op):
@@ -643,10 +640,7 @@ class pgconsul(object):
     def get_replics_info(self, zk_state) -> ReplicaInfos | None:
         stream_from = self.config.get('global', 'stream_from')
         if stream_from:
-            replics_info_path = '{member_path}/{hostname}/replics_info'.format(
-                member_path=self.zk.MEMBERS_PATH, hostname=stream_from
-            )
-            return self.zk.noexcept_get(replics_info_path, preproc=json.loads)
+            return self.zk.get_stream_source_replics_info(stream_from)
         return zk_state[self.zk.REPLICS_INFO_PATH]
 
     def change_primary(self, db_state, primary):
@@ -688,7 +682,7 @@ class pgconsul(object):
     def _get_streaming_replicas(self):
         replics_info = self.db.get_replics_info('primary')
         streaming_app_names = {r['application_name'] for r in replics_info}
-        all_hosts = self.zk.get_children(self.zk.MEMBERS_PATH)
+        all_hosts = self.zk.get_members() or []
         return [fqdn for fqdn in all_hosts if helpers.app_name_from_fqdn(fqdn) in streaming_app_names]
 
     def non_ha_replica_iter(self, db_state, zk_state):
@@ -1011,7 +1005,7 @@ class pgconsul(object):
 
         holder = self.zk.get_current_lock_holder()
         if holder and holder != helpers.get_hostname():
-            last_op = self.zk.noexcept_get('%s/%s/op' % (self.zk.MEMBERS_PATH, helpers.get_hostname()))
+            last_op = self.zk.get_host_op(helpers.get_hostname())
             if role == 'replica' and holder == last_primary and not self.is_op_destructive(last_op):
                 if not is_in_terminal_state:
                     logging.warning('Waiting for postgres to finish starting or stopping.')
@@ -1104,9 +1098,9 @@ class pgconsul(object):
                 return
             self._is_single_node = len(ha_hosts) == 1
             if self._is_single_node:
-                self.zk.ensure_path(self.zk.SINGLE_NODE_PATH)
+                self.zk.set_single_node()
             else:
-                self.zk.delete(self.zk.SINGLE_NODE_PATH)
+                self.zk.clear_single_node()
         else:
             self._is_single_node = self.zk.exists_path(self.zk.SINGLE_NODE_PATH)
 
@@ -1169,18 +1163,13 @@ class pgconsul(object):
     def _reset_simple_primary_switch_try(self):
         logging.debug('Resetting simple primary switch try')
         self.checks['primary_switch'] = 0
-        simple_primary_switch_path = self.zk.get_simple_primary_switch_try_path(get_hostname())
-        if self.zk.noexcept_get(simple_primary_switch_path) != 'no':
-            self.zk.noexcept_write(simple_primary_switch_path, 'no', need_lock=False)
+        self.zk.reset_simple_primary_switch_tried(get_hostname())
 
     def _set_simple_primary_switch_try(self):
-        simple_primary_switch_path = self.zk.get_simple_primary_switch_try_path(get_hostname())
-        self.zk.noexcept_write(simple_primary_switch_path, 'yes', need_lock=False)
+        self.zk.set_simple_primary_switch_tried(get_hostname())
 
     def _is_simple_primary_switch_tried(self):
-        if self.zk.noexcept_get(self.zk.get_simple_primary_switch_try_path(get_hostname())) == 'yes':
-            return True
-        return False
+        return self.zk.get_simple_primary_switch_tried(get_hostname())
 
     def _try_simple_primary_switch_with_lock(self, *args, **kwargs):
         if not self.config.getboolean('global', 'do_consecutive_primary_switch'):
@@ -1252,7 +1241,7 @@ class pgconsul(object):
         ):
             return None
 
-        if not self.zk.write('%s/%s/op' % (self.zk.MEMBERS_PATH, helpers.get_hostname()), 'rewind', need_lock=False):
+        if not self.zk.write_host_op('rewind', helpers.get_hostname()):
             logging.error('Unable to save destructive op state: rewind')
             return None
 
@@ -1268,7 +1257,7 @@ class pgconsul(object):
             return True
 
         # Rewind has finished successfully so we can drop its operation node
-        self.zk.delete('%s/%s/op' % (self.zk.MEMBERS_PATH, helpers.get_hostname()))
+        self.zk.delete_host_op(helpers.get_hostname())
         return self._attach_to_primary(new_primary, limit)
 
     def _attach_to_primary(self, new_primary, limit):
@@ -1310,7 +1299,7 @@ class pgconsul(object):
                 'Can not handle replication slots. We will skip it this time', e
             )
             return
-        all_hosts = self.zk.get_children(self.zk.MEMBERS_PATH)
+        all_hosts = self.zk.get_members()
         if not all_hosts:
             logging.warning(
                 'Could not get all hosts list from ZK.'
@@ -1648,7 +1637,8 @@ class pgconsul(object):
             hostname = app_name_map.get(info['application_name'])
             if not hostname:
                 continue
-            info['priority'] = self.zk.get(self.zk.get_host_prio_path(hostname), preproc=int)
+            prio = self.zk.get_host_prio(hostname)
+            info['priority'] = int(prio) if prio is not None else None
         return replica_infos
 
     def _accept_failover(self, zk_state, switchover_in_progress=False):
@@ -1848,7 +1838,7 @@ class pgconsul(object):
         while True:
             timer = IterationTimer()
             self.zk.ensure_path(self.zk.MEMBERS_PATH)
-            members = self.zk.get_children(self.zk.MEMBERS_PATH)
+            members = self.zk.get_members()
             if members is not None:
                 return members
             self.re_init_zk()

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ from .helpers import IterationTimer, get_hostname, register_sigterm_handler, sho
 from .pg import Postgres, PostgresConfig
 from .replication_manager_factory import create_replication_manager
 from .types import ReplicaInfos
-from .zk import Zookeeper, ZookeeperException
+from .zk import Zookeeper, ZookeeperException, create_zk
 
 
 class pgconsul(object):
@@ -48,7 +48,7 @@ class pgconsul(object):
         random.seed(os.urandom(16))
 
         self.db = Postgres(config=self._postgres_config(), cmd_manager=self._cmd_manager)
-        self.zk = Zookeeper(config=self.config)
+        self.zk = create_zk(config=self.config)
         self.startup_checks()
 
         register_sigterm_handler()

--- a/src/main.py
+++ b/src/main.py
@@ -1102,7 +1102,7 @@ class pgconsul(object):
             else:
                 self.zk.clear_single_node()
         else:
-            self._is_single_node = self.zk.exists_path(self.zk.SINGLE_NODE_PATH)
+            self._is_single_node = self.zk.is_single_node()
 
     def _verify_timeline(self, db_state, zk_state, without_leader_lock=False):
         """

--- a/src/main.py
+++ b/src/main.py
@@ -240,7 +240,7 @@ class pgconsul(object):
         self.stop()
 
     def update_maintenance_status(self, db_state, zk_state):
-        maintenance_status = self.zk.get(self.zk.MAINTENANCE_PATH)  # can be None, 'enable', 'disable'
+        maintenance_status = self.zk.get_maintenance_status()  # can be None, 'enable', 'disable'
         if maintenance_status == 'enable':
             # maintenance node exists with 'enable' value, we are in maintenance now
             self.is_in_maintenance = True
@@ -270,14 +270,14 @@ class pgconsul(object):
             if role == 'primary' and self._update_replication_on_maintenance_enter() and not self._is_single_node:
                 return
             # Write current ts to zk on maintenance enabled, it's be dropped on disable
-            maintenance_ts = self.zk.get(self.zk.MAINTENANCE_TIME_PATH)
+            maintenance_ts = self.zk.get_maintenance_ts()
             if maintenance_ts is None:
-                self.zk.write(self.zk.MAINTENANCE_TIME_PATH, time.time(), need_lock=False)
+                self.zk.write_maintenance_ts()
             # Write current primary to zk on maintenance enabled, it's be dropped on disable
-            current_primary = self.zk.get(self.zk.MAINTENANCE_PRIMARY_PATH)
+            current_primary = self.zk.get_maintenance_primary()
             primary_fqdn = db_state.get('primary_fqdn')
             if current_primary is None and primary_fqdn is not None:
-                self.zk.write(self.zk.MAINTENANCE_PRIMARY_PATH, primary_fqdn, need_lock=False)
+                self.zk.write_maintenance_primary(primary_fqdn)
         elif maintenance_status == 'disable':
             # maintenance node exists with 'disable' value, we are not in maintenance now
             # and should delete this node. We delete it recursively, we don't won't to wait
@@ -288,7 +288,7 @@ class pgconsul(object):
                 log_event('MAINTENANCE ENDED', level='warning')
             self.is_in_maintenance = False
             if self.config.get('global', 'stream_from') is None:
-                self.zk.delete(self.zk.MAINTENANCE_PATH, recursive=True)
+                self.zk.delete_maintenance()
                 log_action = 'deleting maintenance node'
             else:
                 log_action = 'not touching maintenance node as we are non-ha replica'
@@ -342,7 +342,7 @@ class pgconsul(object):
                 self.zk.write_ssn_on_changes(db_state.get('replication_state')[1])
             if self.is_in_maintenance:
                 logging.warning('Cluster in maintenance mode')
-                self.zk.write(self.zk.get_host_maintenance_path(), 'enable', need_lock=False)
+                self.zk.write_host_maintenance_enabled()
                 self.finish_iteration(timer)
                 return
         except ZookeeperException:
@@ -415,7 +415,7 @@ class pgconsul(object):
             return None
         self._store_replics_info(db_state, zk_state)
 
-        self.zk.write(self.zk.TIMELINE_INFO_PATH, db_state['timeline'])
+        self.zk.write_timeline(db_state['timeline'])
 
         self.db.ensure_pooler_started()
         self.db.ensure_archiving_wal()
@@ -459,7 +459,7 @@ class pgconsul(object):
             if not self.zk.try_acquire_lock():
                 self.resolve_zk_primary_lock(my_hostname)
                 return None
-            self.zk.write(self.zk.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
+            self.zk.write_last_primary_availability_time()
 
             self._reset_simple_primary_switch_try()
 
@@ -550,13 +550,13 @@ class pgconsul(object):
     def reset_failover_node(self, zk_state):
         logging.info('Resetting failover node (current state: "%s")', zk_state[self.zk.FAILOVER_STATE_PATH])
         if (
-            self.zk.get(self.zk.FAILOVER_STATE_PATH) == 'finished'
-            or self.zk.write(self.zk.FAILOVER_STATE_PATH, 'finished')
-        ) and self.zk.delete(self.zk.CURRENT_PROMOTING_HOST):
-            self.zk.delete(self.zk.FAILOVER_MUST_BE_RESET)
+            self.zk.get_failover_state() == 'finished'
+            or self.zk.write_failover_state('finished')
+        ) and self.zk.delete_current_promoting_host():
+            self.zk.delete_failover_must_be_reset()
             logging.info('Resetting failover state (was "%s", now "finished")', zk_state[self.zk.FAILOVER_STATE_PATH])
         else:
-            self.zk.ensure_path(self.zk.FAILOVER_MUST_BE_RESET)
+            self.zk.ensure_failover_must_be_reset()
             logging.info('Resetting failover failed, will try on next iteration.')
 
     def resolve_zk_primary_lock(self, my_hostname, close_master_without_lock=True):
@@ -610,34 +610,29 @@ class pgconsul(object):
         stream_from = self.config.get('global', 'stream_from')
         replics_info = db_state.get('replics_info')
         wal_receiver_info = db_state['wal_receiver']
-        host_path = '{member_path}/{hostname}'.format(member_path=self.zk.MEMBERS_PATH, hostname=hostname)
-        replics_info_path = '{host_path}/replics_info'.format(host_path=host_path)
-        ha_path = '{host_path}/ha'.format(host_path=host_path)
-        wal_receiver_path = '{host_path}/wal_receiver'.format(host_path=host_path)
         if not stream_from:
-            if not self.zk.ensure_path(ha_path):
+            if not self.zk.ensure_host_ha(hostname):
                 logging.warning('Could not write ha host in ZK.')
                 return False
         else:
-            if self.zk.exists_path(ha_path) and not self.zk.delete(ha_path):
+            if not self.zk.delete_host_ha(hostname):
                 logging.warning('Could not delete ha host in ZK.')
                 return False
         if wal_receiver_info is not None:
-            if not self.zk.write(wal_receiver_path, wal_receiver_info, preproc=json.dumps, need_lock=False):
+            if not self.zk.write_host_wal_receiver(wal_receiver_info, hostname):
                 logging.warning('Could not write host wal_receiver_info to ZK.')
                 return False
         if replics_info is not None:
-            if not self.zk.write(replics_info_path, replics_info, preproc=json.dumps, need_lock=False):
+            if not self.zk.write_host_replics_info(replics_info, hostname):
                 logging.warning('Could not write host replics_info to ZK.')
                 return False
         self.last_zk_host_stat_write = time.time()
 
     def remove_stale_operation(self, hostname):
-        op_path = '%s/%s/op' % (self.zk.MEMBERS_PATH, hostname)
-        last_op = self.zk.noexcept_get(op_path)
+        last_op = self.zk.get_host_op(hostname)
         if self.is_op_destructive(last_op):
             logging.warning('Stale operation %s detected. Removing track from zk.', last_op)
-            self.zk.delete(op_path)
+            self.zk.delete_host_op(hostname)
 
     def start_pooler(self):
         start_pooler = self.config.getboolean('replica', 'start_pooler')
@@ -804,7 +799,7 @@ class pgconsul(object):
         logging.info('Switchover record found in ZK')
 
         # We check that switchover should happen from current timeline
-        zk_tli = self.zk.get(self.zk.TIMELINE_INFO_PATH, preproc=int)
+        zk_tli = self.zk.get_timeline()
         sw_tli = switchover_info[self.zk.TIMELINE_INFO_PATH]
         if zk_tli != sw_tli:
             logging.warning('ZK timeline %s differs from switchover timeline %s, ignoring switchover', zk_tli, sw_tli)
@@ -870,7 +865,7 @@ class pgconsul(object):
 
             logging.info('Current host is the candidate and ready, signaling primary...')
             # do not overwrite status
-            if not self.zk.write(self.zk.SWITCHOVER_STATE_PATH, 'candidate_found', need_lock=False):
+            if not self.zk.write_switchover_state('candidate_found'):
                 logging.error('Failed to state that we are the new primary candidate in ZK.')
                 return False
         else:
@@ -886,12 +881,15 @@ class pgconsul(object):
             logging.info('Could not acquire lock in ZK. Not doing anything.')
             return False
 
-        switchover_info = self.zk.get(self.zk.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
+        switchover_info = self.zk.get_switchover_primary_info()
+        if switchover_info is None:
+            logging.error('Failed to get switchover primary info from ZK.')
+            return False
         if not self._do_failover(old_primary=switchover_info.get('hostname')):
             return False
 
         self._cleanup_switchover()
-        self.zk.write(self.zk.LAST_SWITCHOVER_TIME_PATH, time.time())
+        self.zk.write_last_switchover_time()
         self._stop_timing('switchover')
 
         return True
@@ -1062,10 +1060,10 @@ class pgconsul(object):
         if not self.zk.try_acquire_lock(self.zk.SWITCHOVER_LOCK_PATH):
             return
         try:
-            switchover_info = self.zk.get(self.zk.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
+            switchover_info = self.zk.get_switchover_primary_info()
             if not switchover_info:
                 return
-            switchover_state = self.zk.get(self.zk.SWITCHOVER_STATE_PATH)
+            switchover_state = self.zk.get_switchover_state()
             if (
                 switchover_state != 'scheduled'
                 or switchover_info.get(self.zk.TIMELINE_INFO_PATH) is None
@@ -1091,11 +1089,7 @@ class pgconsul(object):
 
     def _cleanup_switchover(self):
         logging.info('Cleaning up switchover info...')
-        self.zk.delete(self.zk.SWITCHOVER_CANDIDATE)
-        self.zk.delete(self.zk.SWITCHOVER_SIDE_REPLICAS)
-        self.zk.delete(self.zk.SWITCHOVER_STATE_PATH)
-        self.zk.delete(self.zk.SWITCHOVER_PRIMARY_PATH)
-        self.zk.delete(self.zk.FAILOVER_STATE_PATH)
+        self.zk.cleanup_switchover()
 
     def _update_single_node_status(self, role):
         """
@@ -1142,7 +1136,7 @@ class pgconsul(object):
             if without_leader_lock:
                 return True
             logging.warning('Could not get timeline from ZK. Saving it.')
-            self.zk.write(self.zk.TIMELINE_INFO_PATH, db_state['timeline'])
+            self.zk.write_timeline(db_state['timeline'])
         # If there is a mismatch in timeline:
         # - If ZK timeline is greater than local, there must be another primary.
         #   In that case local instance have no business holding the lock.
@@ -1168,7 +1162,7 @@ class pgconsul(object):
                 if without_leader_lock:
                     return True
                 logging.warning('Timeline in ZK is older than ours. Updating it it ZK.')
-                self.zk.write(self.zk.TIMELINE_INFO_PATH, db_tli)
+                self.zk.write_timeline(db_tli)
         logging.debug('Timeline verification succeeded')
         return True
 
@@ -1393,7 +1387,7 @@ class pgconsul(object):
         logging.debug("primary_switch checks is %d", self.checks['primary_switch'])
 
         self._acquire_replication_source_slot_lock(new_primary)
-        failover_state = self.zk.noexcept_get(self.zk.FAILOVER_STATE_PATH)
+        failover_state = self.zk.get_failover_state()
         if failover_state is not None and failover_state not in ('finished', 'promoting', 'checkpointing') and not skip_check:
             logging.info(
                 'We are not able to return to cluster since failover is still in progress - %s.', failover_state
@@ -1452,11 +1446,11 @@ class pgconsul(object):
         return self._rewind_from_source(is_dead, limit, new_primary)
 
     def _promote(self):
-        if not self.zk.write(self.zk.FAILOVER_STATE_PATH, 'promoting'):
+        if not self.zk.write_failover_state('promoting'):
             logging.error('Could not write failover state to ZK.')
             return False
 
-        if not self.zk.write(self.zk.CURRENT_PROMOTING_HOST, helpers.get_hostname()):
+        if not self.zk.write_current_promoting_host():
             logging.error('Could not write self as last promoted host.')
             return False
 
@@ -1469,9 +1463,9 @@ class pgconsul(object):
             # we simply return False here.
             if self.db.get_role() != 'primary':
                 self.db.pgpooler('stop')
-                if not self.zk.delete(self.zk.CURRENT_PROMOTING_HOST):
+                if not self.zk.delete_current_promoting_host():
                     logging.error('Could not remove self as current promoting host.')
-                if not self.zk.write(self.zk.FAILOVER_STATE_PATH, 'finished'):
+                if not self.zk.write_failover_state('finished'):
                     logging.error('Could not write failover state to ZK.')
                 return False
 
@@ -1481,7 +1475,7 @@ class pgconsul(object):
 
         self._slot_drop_countdown = {}
 
-        if not self.zk.noexcept_write(self.zk.FAILOVER_STATE_PATH, 'checkpointing'):
+        if not self.zk.write_failover_state('checkpointing'):
             logging.warning('Could not write failover state to ZK.')
 
         logging.debug('Doing checkpoint after promoting.')
@@ -1490,13 +1484,13 @@ class pgconsul(object):
 
         my_tli = self.db.get_timeline()
 
-        if not self.zk.write(self.zk.TIMELINE_INFO_PATH, my_tli):
+        if not self.zk.write_timeline(my_tli):
             logging.warning('Could not write timeline to ZK.')
 
-        if not self.zk.write(self.zk.FAILOVER_STATE_PATH, 'finished'):
+        if not self.zk.write_failover_state('finished'):
             logging.error('Could not write failover state to ZK.')
 
-        if not self.zk.delete(self.zk.CURRENT_PROMOTING_HOST):
+        if not self.zk.delete_current_promoting_host():
             logging.error('Could not remove self as current promoting host.')
 
         return True
@@ -1511,7 +1505,7 @@ class pgconsul(object):
         return True
 
     def _promote_handle_slots(self):
-        if not self.zk.write(self.zk.FAILOVER_STATE_PATH, 'creating_slots'):
+        if not self.zk.write_failover_state('creating_slots'):
             logging.warning('Could not write failover state to ZK.')
         hosts = self._get_ha_replics()
         if hosts is None:
@@ -1526,7 +1520,7 @@ class pgconsul(object):
     def _check_my_timeline_sync(self):
         my_tli = self.db.get_timeline()
         try:
-            zk_tli = self.zk.get(self.zk.TIMELINE_INFO_PATH, preproc=int)
+            zk_tli = self.zk.get_timeline()
         except ZookeeperException:
             logging.error('Could not get timeline from ZK.')
             return False
@@ -1543,11 +1537,10 @@ class pgconsul(object):
         return True
 
     def _check_last_failover_timeout(self):
-        try:
-            last_failover_ts = self.zk.get(self.zk.LAST_FAILOVER_TIME_PATH, preproc=float)
-        except ZookeeperException:
-            logging.error('Can\'t get last failover time from ZK.')
-            return False
+        last_failover_ts = self.zk.get_last_failover_time()
+        if last_failover_ts is None:
+            logging.warning('There was no last failover ts in ZK. Skipping this check.')
+            last_failover_ts = 0.0
 
         if last_failover_ts is None:
             logging.warning('There was no last failover ts in ZK. Skipping this check.')
@@ -1560,7 +1553,7 @@ class pgconsul(object):
         return True
 
     def _check_primary_unavailability_timeout(self):
-        previous_primary_availability_time = self.zk.noexcept_get(self.zk.LAST_PRIMARY_AVAILABILITY_TIME, preproc=float)
+        previous_primary_availability_time = self.zk.get_last_primary_availability_time()
         if previous_primary_availability_time is None:
             logging.error('Failed to get last primary availability time.')
             return False
@@ -1636,7 +1629,7 @@ class pgconsul(object):
             return False
 
     def _get_switchover_candidate(self):
-        switchover_info = self.zk.get(self.zk.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
+        switchover_info = self.zk.get_switchover_primary_info()
         if switchover_info is None:
             return None
         if switchover_info.get('destination') is not None:
@@ -1650,7 +1643,7 @@ class pgconsul(object):
         return self._replication_manager.get_ensured_sync_replica(replica_infos)
 
     def _get_extended_replica_infos(self) -> ReplicaInfos | None:
-        replica_infos = self.zk.get(self.zk.REPLICS_INFO_PATH, preproc=json.loads)
+        replica_infos = self.zk.get_replics_info()
         if replica_infos is None:
             logging.error('Unable to get replica infos from ZK.')
             return None
@@ -1684,11 +1677,11 @@ class pgconsul(object):
         if not self._do_failover():
             return False
 
-        self.zk.write(self.zk.LAST_FAILOVER_TIME_PATH, time.time())
+        self.zk.write_last_failover_time()
         self._stop_timing('failover')
 
     def _do_failover(self, old_primary=None):
-        if not self.zk.delete(self.zk.FAILOVER_STATE_PATH):
+        if not self.zk.delete_failover_state():
             logging.error('Could not remove previous failover state. Releasing the lock.')
             self.zk.release_lock()
             return False
@@ -1762,12 +1755,9 @@ class pgconsul(object):
 
     def _get_replics_info_from_zk(self, primary) -> ReplicaInfos | None:
         if primary:
-            replics_info_path = '{member_path}/{hostname}/replics_info'.format(
-                member_path=self.zk.MEMBERS_PATH, hostname=primary
-            )
+            return self.zk.get_host_replics_info(primary)
         else:
-            replics_info_path = self.zk.REPLICS_INFO_PATH
-        return self.zk.get(replics_info_path, preproc=json.loads)
+            return self.zk.get_replics_info()
 
     @staticmethod
     def _is_caught_up(replica_infos: ReplicaInfos):
@@ -1893,7 +1883,7 @@ class pgconsul(object):
             return None
 
         # There were no failed attempts in the past
-        switchover_state = self.zk.get(self.zk.SWITCHOVER_STATE_PATH)
+        switchover_state = self.zk.get_switchover_state()
         # Ignore silently if node does not exist
         if switchover_state is None:
             logging.warning('Switchover state is empty, ignoring switchover')
@@ -1904,7 +1894,7 @@ class pgconsul(object):
             return None
 
         # Timeline of the current instance matches the timeline defined in SS node.
-        zk_tli = self.zk.get(self.zk.TIMELINE_INFO_PATH, preproc=int)
+        zk_tli = self.zk.get_timeline()
         sw_tli = switchover_info[self.zk.TIMELINE_INFO_PATH]
         if zk_tli != sw_tli:
             logging.warning('ZK timeline %s differs from switchover timeline %s, ignoring switchover', zk_tli, sw_tli)
@@ -1983,27 +1973,27 @@ class pgconsul(object):
             return False
 
         logging.info('Fixing switchover candidate to %s', switchover_candidate)
-        if not self.zk.write(self.zk.SWITCHOVER_CANDIDATE, switchover_candidate):
+        if not self.zk.write_switchover_candidate(switchover_candidate):
             logging.error('Failed to fix switchover candidate')
             return False
 
         side_replicas = self._get_streaming_replicas()
         side_replicas = [r for r in side_replicas if r != switchover_candidate]
         logging.info('Fixing side replicas to %s', side_replicas)
-        if not self.zk.write(self.zk.SWITCHOVER_SIDE_REPLICAS, side_replicas, preproc=json.dumps):
+        if not self.zk.write_switchover_side_replicas(side_replicas):
             logging.error('Failed to fix side replicas')
             return False
 
         logging.warning('Starting scheduled switchover')
-        self.zk.write(self.zk.SWITCHOVER_STATE_PATH, 'initiated')
+        self.zk.write_switchover_state('initiated')
 
         # for back compatibility
-        self.zk.write(self.zk.FAILOVER_STATE_PATH, 'switchover_initiated')
+        self.zk.write_failover_state('switchover_initiated')
 
         # wait for candidate ready to proceed
         timeout = self.config.getfloat('global', 'switchover_replica_turn_timeout')
         if not helpers.await_for(
-            lambda: self.zk.get(self.zk.SWITCHOVER_STATE_PATH) == 'candidate_found',
+            lambda: self.zk.get_switchover_state() == 'candidate_found',
             timeout, "switchover candidate found",
         ):
             return False
@@ -2043,7 +2033,7 @@ class pgconsul(object):
             return False
 
         # for back compatibility
-        self.zk.write(self.zk.FAILOVER_STATE_PATH, 'switchover_master_shut')
+        self.zk.write_failover_state('switchover_master_shut')
 
         # Release leader-lock.
         # Wait 5 secs for the actual release.
@@ -2064,7 +2054,7 @@ class pgconsul(object):
         timeout = self.config.getfloat('global', 'switchover_rollback_timeout')
         if not self._wait_for_new_master_and_return_to_cluster(timeout):
             logging.warning('Failing and rolling back switchover')
-            self.zk.write(self.zk.SWITCHOVER_STATE_PATH, 'failed')
+            self.zk.write_switchover_state('failed')
             return False
 
         return True
@@ -2127,18 +2117,18 @@ class pgconsul(object):
         the procedure.
         """
         if helpers.await_for(
-            lambda: self.zk.get(self.zk.SWITCHOVER_STATE_PATH) is None, timeout, 'new primary finished switchover',
+            lambda: self.zk.get_switchover_state() is None, timeout, 'new primary finished switchover',
         ):
             primary = self.zk.get_current_lock_holder(self.zk.PRIMARY_LOCK_PATH)
             if primary is not None:
                 # From here switchover can be considered successful regardless of this host state
-                self.zk.delete('%s/%s/op' % (self.zk.MEMBERS_PATH, helpers.get_hostname()))
+                self.zk.delete_host_op()
                 self._set_simple_primary_switch_try()
                 self._rewind_from_source(is_postgresql_dead=True, limit=timeout, new_primary=primary)
                 return True
             logging.warning(f'SWITCHOVER_STATE_PATH ({self.zk.SWITCHOVER_STATE_PATH}) became None, but there is no one, who holds the leader lock.')
         else:
-            logging.warning(f'SWITCHOVER_STATE_PATH ({self.zk.SWITCHOVER_STATE_PATH}) has value {self.zk.get(self.zk.SWITCHOVER_STATE_PATH)}'
+            logging.warning(f'SWITCHOVER_STATE_PATH ({self.zk.SWITCHOVER_STATE_PATH}) has value {self.zk.get_switchover_state()}'
                              ', but expected to be None in timeout. Hope that the new master is doing well.')
         # acquiring lock means replica failed to promote, its switchover failure - should return False
         return not self.zk.try_acquire_lock(allow_queue=True, timeout=timeout)
@@ -2154,7 +2144,7 @@ class pgconsul(object):
                 self.zk.try_acquire_lock(self.zk.get_host_alive_lock_path())
 
     def _zk_get_wal_receiver_info(self, host):
-        return self.zk.get(f'{self.zk.MEMBERS_PATH}/{host}/wal_receiver', preproc=json.loads)
+        return self.zk.get_host_wal_receiver(host)
 
     def is_op_destructive(self, op):
         return op in self.DESTRUCTIVE_OPERATIONS
@@ -2168,9 +2158,7 @@ class pgconsul(object):
 
         zk_state['replics_info_written'] = None
         if tli_res and replics_info is not None:
-            zk_state['replics_info_written'] = self.zk.write(
-                self.zk.REPLICS_INFO_PATH, replics_info, preproc=json.dumps
-            )
+            zk_state['replics_info_written'] = self.zk.write_replics_info(replics_info)
             self.write_host_stat(helpers.get_hostname(), db_state)
             return True
 
@@ -2194,17 +2182,15 @@ class pgconsul(object):
         return self.db.stop_postgresql(timeout=timeout, wait=wait)
 
     def _get_timing_start(self, name):
-        return self.zk.noexcept_get(self.zk.get_timing_path(name), preproc=float)
+        return self.zk.get_timing(name)
 
     def _start_timing(self, name, ts=None):
         if ts is None:
             ts = time.time()
-        path = self.zk.get_timing_path(name)
-        self.zk.ensure_path(path)
-        self.zk.noexcept_write(path, ts, need_lock=False)
+        self.zk.write_timing(name, ts)
 
     def _clear_timing(self, name):
-        self.zk.delete(self.zk.get_timing_path(name), recursive=True)
+        self.zk.delete_timing(name)
 
     def _stop_timing(self, name, track_as=None):
         start = self._get_timing_start(name)

--- a/src/replication_manager.py
+++ b/src/replication_manager.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 
@@ -40,7 +39,7 @@ class ReplicationManager:
         self._zk_fail_timestamp = None
 
     def init_zk(self):
-        if not self._zk.ensure_path(self._zk.QUORUM_PATH):
+        if not self._zk.ensure_quorum_path():
             logging.error("Can't create quorum path in ZK")
             return False
         return True
@@ -154,7 +153,7 @@ class ReplicationManager:
             if repl_state == 'async':
                 logging.debug('We should not change replication type here.')
                 return
-            self._zk.write(self._zk.QUORUM_PATH, [], preproc=json.dumps)
+            self._zk.clear_quorum()
             self.change_replication_to_async()
             return
 
@@ -165,8 +164,8 @@ class ReplicationManager:
         if not quorum_hosts:
             logging.error('ACTION-FAILED. No quorum hosts holding locks: Not doing anything.')
             return
-        
-        quorum = self._zk.get(self._zk.QUORUM_PATH, preproc=helpers.load_json_or_default)
+
+        quorum = self._zk.get_quorum()
         if quorum is None:
             quorum = []
 
@@ -201,7 +200,7 @@ class ReplicationManager:
             )
         
         if self.change_replication_to_quorum(quorum_hosts_final):
-            self._zk.write(self._zk.QUORUM_PATH, quorum_hosts_final, preproc=json.dumps)
+            self._zk.write_quorum(quorum_hosts_final)
             if repl_state == 'async':
                 logging.info('Turned synchronous replication ON.')
             else:
@@ -234,7 +233,7 @@ class ReplicationManager:
 
     def change_replication_to_async(self, reset_sync_replication_in_zk=True):
         if reset_sync_replication_in_zk:
-            self._zk.write(self._zk.QUORUM_PATH, [], preproc=json.dumps)
+            self._zk.clear_quorum()
         logging.warning("We should kill synchronous replication here.")
         return self._ssn.apply_and_persist('', 'Turning synchronous replication OFF.', 'Turned synchronous replication OFF.')
 
@@ -249,7 +248,7 @@ class ReplicationManager:
         self._zk.release_if_hold(self._zk.get_host_quorum_path())
 
     def is_promote_safe(self, host_group, replica_infos: ReplicaInfos):
-        sync_quorum = self._zk.get(self._zk.QUORUM_PATH, preproc=helpers.load_json_or_default)
+        sync_quorum = self._zk.get_quorum()
         alive_replics = helpers.make_current_replics_quorum(replica_infos, host_group)
         logging.info('Sync quorum was: %s', sync_quorum)
         logging.info('Alive hosts was: %s', host_group)
@@ -261,7 +260,7 @@ class ReplicationManager:
         return hosts_in_quorum >= len(sync_quorum) // 2 + 1
 
     def get_ensured_sync_replica(self, replica_infos: ReplicaInfos):
-        quorum = self._zk.get(self._zk.QUORUM_PATH, preproc=helpers.load_json_or_default)
+        quorum = self._zk.get_quorum()
         if quorum is None:
             quorum = []
         sync_quorum = {helpers.app_name_from_fqdn(host): host for host in quorum}

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,7 +12,7 @@ from os import getpid
 
 from . import read_config, zk, helpers
 from .exceptions import SwitchoverException, FailoverException
-from .zk import ZookeeperException
+from .zk import create_zk, ZookeeperException
 
 
 class Switchover:
@@ -52,7 +52,7 @@ class Switchover:
         lock_contender_name = None
         if from_cli:
             lock_contender_name = helpers.get_hostname() + '_' + str(getpid())
-        self._zk = zk.Zookeeper(config=conf, lock_contender_name=lock_contender_name)
+        self._zk = create_zk(config=conf, lock_contender_name=lock_contender_name)
         # If primary or syncrep or timeline is provided, use them instead.
         # Autodetect (from ZK) if none.
         self._new_primary = new_primary
@@ -337,7 +337,7 @@ class Failover:
         if conf is None:
             conf = read_config({'config_file': config_path})
         self._conf = conf
-        self._zk = zk.Zookeeper(config=conf)
+        self._zk = create_zk(config=conf)
 
     def reset(self):
         """

--- a/src/zk.py
+++ b/src/zk.py
@@ -349,9 +349,13 @@ class Zookeeper(object):
             logging.exception('Failed to write zk node')
             return False
 
-    def delete(self, key, recursive=False):
-        """Delete key from zk"""
-        return self._zk_client.delete(key, recursive=recursive)
+    def delete(self, key, recursive=False) -> bool:
+        """Delete key from zk. Returns True on success or when absent, False on error."""
+        try:
+            return self._zk_client.delete(key, recursive=recursive)
+        except ZkClientError:
+            logging.exception('Failed to delete zk node %s', key)
+            return False
 
     def get_lock_contenders(self, name, catch_except=True, read_lock=False):
         """Get all hostnames competing for the lock, including the holder."""
@@ -457,8 +461,8 @@ class Zookeeper(object):
                 self.write(date_path, time.time(), need_lock=False)
 
             return True
-        except Exception as exc:
-            logging.exception(exc)
+        except Exception:
+            logging.exception('Failed to write SSN on changes')
             return False
 
     def _get_election_vote_path(self, hostname=None):
@@ -556,12 +560,7 @@ class Zookeeper(object):
         path = self._get_host_ha_path(hostname)
         if not self.exists_path(path):
             return True
-        try:
-            self.delete(path)
-            return True
-        except Exception:
-            logging.exception('Failed to delete host ha path')
-            return False
+        return self.delete(path)
 
     def _get_host_replics_info_path(self, hostname=None):
         return helpers.get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)

--- a/src/zk.py
+++ b/src/zk.py
@@ -75,6 +75,10 @@ class Zookeeper(object):
     MEMBERS_PATH = 'all_hosts'
     SIMPLE_PRIMARY_SWITCH_TRY_PATH = f'{MEMBERS_PATH}/%s/tried_remaster'
     HOST_PRIO_PATH = f'{MEMBERS_PATH}/%s/prio'
+    HOST_OP_PATH = f'{MEMBERS_PATH}/%s/op'
+    HOST_REPLICS_INFO_PATH = f'{MEMBERS_PATH}/%s/replics_info'
+    HOST_WAL_RECEIVER_PATH = f'{MEMBERS_PATH}/%s/wal_receiver'
+    HOST_HA_PATH = f'{MEMBERS_PATH}/%s/ha'
     SSN_PATH = f'{MEMBERS_PATH}/%s/synchronous_standby_names'
     SSN_VALUE_PATH = f'{SSN_PATH}/value'
     SSN_DATE_PATH = f'{SSN_PATH}/last_update'
@@ -746,6 +750,335 @@ class Zookeeper(object):
                 ha_hosts.append(host)
         logging.debug(f"HA hosts are: {ha_hosts}")
         return ha_hosts
+
+    # === Host-level business methods ===
+
+    def get_host_op_path(self, hostname=None):
+        """Return path to the op node for the host."""
+        return _get_host_path(self.HOST_OP_PATH, hostname)
+
+    def get_host_op(self, hostname=None):
+        """Get the current operation state for a host."""
+        return self.noexcept_get(self.get_host_op_path(hostname))
+
+    def write_host_op(self, op: str, hostname=None) -> bool:
+        """Write operation state for a host."""
+        return self.noexcept_write(self.get_host_op_path(hostname), op, need_lock=False)
+
+    def delete_host_op(self, hostname=None) -> bool:
+        """Delete operation state for a host."""
+        try:
+            self.delete(self.get_host_op_path(hostname))
+            return True
+        except Exception:
+            logging.exception('Failed to delete host op path')
+            return False
+
+    def get_host_ha_path(self, hostname=None):
+        """Return path to the ha node for the host."""
+        return _get_host_path(self.HOST_HA_PATH, hostname)
+
+    def ensure_host_ha(self, hostname=None) -> bool:
+        """Ensure the ha node exists for a host. Returns True on success."""
+        result = self.ensure_path(self.get_host_ha_path(hostname))
+        return result is not None
+
+    def delete_host_ha(self, hostname=None) -> bool:
+        """Delete the ha node for a host. Returns False on failure."""
+        try:
+            self.delete(self.get_host_ha_path(hostname))
+            return True
+        except Exception:
+            logging.exception('Failed to delete host ha path')
+            return False
+
+    def get_host_replics_info_path(self, hostname=None):
+        """Return path to the replics_info node for the host."""
+        return _get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)
+
+    def write_host_replics_info(self, replics_info, hostname=None) -> bool:
+        """Write replics_info JSON for a host."""
+        return self.noexcept_write(
+            self.get_host_replics_info_path(hostname), replics_info, preproc=json.dumps, need_lock=False
+        )
+
+    def get_host_replics_info(self, hostname) -> list | None:
+        """Get replics_info JSON for a host."""
+        return self.get(self.get_host_replics_info_path(hostname), preproc=json.loads)
+
+    def get_host_wal_receiver_path(self, hostname):
+        """Return path to the wal_receiver node for the host."""
+        return _get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
+
+    def write_host_wal_receiver(self, wal_receiver_info, hostname=None) -> bool:
+        """Write wal_receiver_info JSON for a host."""
+        return self.noexcept_write(
+            self.get_host_wal_receiver_path(hostname), wal_receiver_info, preproc=json.dumps, need_lock=False
+        )
+
+    def get_host_wal_receiver(self, hostname) -> dict | None:
+        """Get wal_receiver_info JSON for a host."""
+        return self.get(self.get_host_wal_receiver_path(hostname), preproc=json.loads)
+
+    # === Maintenance methods ===
+
+    def get_maintenance_status(self) -> str | None:
+        """Get current maintenance status."""
+        return self.get(self.MAINTENANCE_PATH)
+
+    def delete_maintenance(self) -> bool:
+        """Delete maintenance node and all its children."""
+        try:
+            self.delete(self.MAINTENANCE_PATH, recursive=True)
+            return True
+        except Exception:
+            logging.exception('Failed to delete maintenance path')
+            return False
+
+    def get_maintenance_ts(self) -> str | None:
+        """Get maintenance timestamp."""
+        return self.get(self.MAINTENANCE_TIME_PATH)
+
+    def write_maintenance_ts(self) -> bool:
+        """Write current time as maintenance timestamp."""
+        try:
+            self.write(self.MAINTENANCE_TIME_PATH, time.time(), need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write maintenance timestamp')
+            return False
+
+    def get_maintenance_primary(self) -> str | None:
+        """Get primary hostname that set maintenance."""
+        return self.get(self.MAINTENANCE_PRIMARY_PATH)
+
+    def write_maintenance_primary(self, primary_fqdn: str) -> bool:
+        """Write primary hostname that is setting maintenance."""
+        try:
+            self.write(self.MAINTENANCE_PRIMARY_PATH, primary_fqdn, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write maintenance primary')
+            return False
+
+    def write_host_maintenance_enabled(self, hostname=None) -> bool:
+        """Write 'enable' to host maintenance path."""
+        try:
+            self.write(self.get_host_maintenance_path(hostname), 'enable', need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write host maintenance enabled')
+            return False
+
+    # === Timeline methods ===
+
+    def get_timeline(self) -> int | None:
+        """Get current timeline from ZooKeeper."""
+        return self.get(self.TIMELINE_INFO_PATH, preproc=int)
+
+    def write_timeline(self, timeline: int) -> bool:
+        """Write timeline to ZooKeeper."""
+        try:
+            self.write(self.TIMELINE_INFO_PATH, timeline)
+            return True
+        except Exception:
+            logging.exception('Failed to write timeline')
+            return False
+
+    # === Global replics_info methods ===
+
+    def get_replics_info(self) -> list | None:
+        """Get global replics_info list from ZooKeeper."""
+        return self.get(self.REPLICS_INFO_PATH, preproc=json.loads)
+
+    def noexcept_get_replics_info(self) -> list | None:
+        """Get global replics_info list without raising exceptions."""
+        return self.noexcept_get(self.REPLICS_INFO_PATH, preproc=json.loads)
+
+    def write_replics_info(self, replics_info) -> bool:
+        """Write global replics_info list to ZooKeeper."""
+        try:
+            self.write(self.REPLICS_INFO_PATH, replics_info, preproc=json.dumps)
+            return True
+        except Exception:
+            logging.exception('Failed to write replics_info')
+            return False
+
+    # === Failover state methods ===
+
+    def get_failover_state(self) -> str | None:
+        """Get current failover state."""
+        return self.noexcept_get(self.FAILOVER_STATE_PATH)
+
+    def write_failover_state(self, state: str) -> bool:
+        """Write failover state to ZooKeeper."""
+        try:
+            self.write(self.FAILOVER_STATE_PATH, state)
+            return True
+        except Exception:
+            logging.exception('Failed to write failover state')
+            return False
+
+    def delete_failover_state(self) -> bool:
+        """Delete failover state node."""
+        try:
+            self.delete(self.FAILOVER_STATE_PATH)
+            return True
+        except Exception:
+            logging.exception('Failed to delete failover state')
+            return False
+
+    def write_current_promoting_host(self, hostname=None) -> bool:
+        """Write current promoting host to ZooKeeper."""
+        try:
+            if hostname is None:
+                hostname = helpers.get_hostname()
+            self.write(self.CURRENT_PROMOTING_HOST, hostname)
+            return True
+        except Exception:
+            logging.exception('Failed to write current promoting host')
+            return False
+
+    def delete_current_promoting_host(self) -> bool:
+        """Delete current promoting host node."""
+        try:
+            self.delete(self.CURRENT_PROMOTING_HOST)
+            return True
+        except Exception:
+            logging.exception('Failed to delete current promoting host')
+            return False
+
+    def ensure_failover_must_be_reset(self) -> bool:
+        """Ensure failover_must_be_reset flag exists."""
+        result = self.ensure_path(self.FAILOVER_MUST_BE_RESET)
+        return result is not None
+
+    def delete_failover_must_be_reset(self) -> bool:
+        """Delete failover_must_be_reset flag."""
+        try:
+            self.delete(self.FAILOVER_MUST_BE_RESET)
+            return True
+        except Exception:
+            logging.exception('Failed to delete failover_must_be_reset')
+            return False
+
+    def get_last_failover_time(self) -> float | None:
+        """Get last failover timestamp."""
+        return self.get(self.LAST_FAILOVER_TIME_PATH, preproc=float)
+
+    def write_last_failover_time(self) -> bool:
+        """Write current time as last failover timestamp."""
+        try:
+            self.write(self.LAST_FAILOVER_TIME_PATH, time.time(), need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write last failover time')
+            return False
+
+    def get_last_primary_availability_time(self) -> float | None:
+        """Get last primary availability timestamp."""
+        return self.noexcept_get(self.LAST_PRIMARY_AVAILABILITY_TIME, preproc=float)
+
+    def write_last_primary_availability_time(self) -> bool:
+        """Write current time as last primary availability timestamp."""
+        try:
+            self.write(self.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
+            return True
+        except Exception:
+            logging.exception('Failed to write last primary availability time')
+            return False
+
+    def get_last_switchover_time(self) -> float | None:
+        """Get last switchover timestamp."""
+        return self.get(self.LAST_SWITCHOVER_TIME_PATH, preproc=float)
+
+    # === Switchover methods ===
+
+    def get_switchover_state(self) -> str | None:
+        """Get current switchover state."""
+        return self.get(self.SWITCHOVER_STATE_PATH)
+
+    def write_switchover_state(self, state: str) -> bool:
+        """Write switchover state to ZooKeeper."""
+        try:
+            self.write(self.SWITCHOVER_STATE_PATH, state, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write switchover state')
+            return False
+
+    def get_switchover_primary_info(self) -> dict | None:
+        """Get switchover primary info (JSON with fqdn and timeline)."""
+        return self.get(self.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
+
+    def write_switchover_candidate(self, candidate: str) -> bool:
+        """Write switchover candidate hostname."""
+        try:
+            self.write(self.SWITCHOVER_CANDIDATE, candidate)
+            return True
+        except Exception:
+            logging.exception('Failed to write switchover candidate')
+            return False
+
+    def get_switchover_candidate_host(self) -> str | None:
+        """Get switchover candidate hostname."""
+        return self.get(self.SWITCHOVER_CANDIDATE)
+
+    def write_switchover_side_replicas(self, replicas: list) -> bool:
+        """Write switchover side replicas list."""
+        try:
+            self.write(self.SWITCHOVER_SIDE_REPLICAS, replicas, preproc=json.dumps)
+            return True
+        except Exception:
+            logging.exception('Failed to write switchover side replicas')
+            return False
+
+    def write_last_switchover_time(self) -> bool:
+        """Write current time as last switchover timestamp."""
+        try:
+            self.write(self.LAST_SWITCHOVER_TIME_PATH, time.time(), need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write last switchover time')
+            return False
+
+    def cleanup_switchover(self) -> None:
+        """Clean up all switchover-related nodes."""
+        paths_to_delete = [
+            self.SWITCHOVER_CANDIDATE,
+            self.SWITCHOVER_SIDE_REPLICAS,
+            self.SWITCHOVER_STATE_PATH,
+            self.SWITCHOVER_PRIMARY_PATH,
+            self.FAILOVER_STATE_PATH,
+        ]
+        for path in paths_to_delete:
+            try:
+                self.delete(path)
+            except Exception:
+                logging.debug('Failed to delete switchover path: %s', path)
+
+    # === Timing methods ===
+
+    def get_timing(self, name: str) -> float | None:
+        """Get timing value by name."""
+        return self.noexcept_get(self.get_timing_path(name), preproc=float)
+
+    def write_timing(self, name: str, ts: float) -> None:
+        """Write timing value. Ensures path exists before writing."""
+        try:
+            self.ensure_path(self.get_timing_path(name))
+            self.noexcept_write(self.get_timing_path(name), ts, need_lock=False)
+        except Exception:
+            logging.exception('Failed to write timing: %s', name)
+
+    def delete_timing(self, name: str) -> bool:
+        """Delete timing node by name."""
+        try:
+            self.delete(self.get_timing_path(name), recursive=True)
+            return True
+        except Exception:
+            logging.exception('Failed to delete timing: %s', name)
+            return False
 
     def is_host_alive(self, hostname, timeout=0.0, catch_except=True):
         alive_path = self.get_host_alive_lock_path(hostname)

--- a/src/zk.py
+++ b/src/zk.py
@@ -96,16 +96,26 @@ class Zookeeper(object):
         self._zk_client.set_state_listener(self._listener)
         self._init_lock(self.PRIMARY_LOCK_PATH)
 
-    def close(self) -> None:
-        """Release all locks and close ZK connection."""
+    def _drop_all_locks(self) -> None:
+        """Release all held locks, swallow errors, clear the registry."""
         for lock in list(self._locks.values()):
             try:
                 if lock:
                     lock.release()
             except Exception:
-                logging.debug("Error releasing lock during close", exc_info=True)
+                logging.debug("Error releasing lock", exc_info=True)
         self._locks = {}
+
+    def close(self) -> None:
+        """Release all locks and close ZK connection."""
+        self._drop_all_locks()
         self._zk_client.close()
+
+    def __enter__(self) -> 'Zookeeper':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
 
     def _get_lock_contender_name(self):
         if self.config.lock_contender_name:
@@ -206,14 +216,7 @@ class Zookeeper(object):
         Other locks are re-acquired lazily on the next iteration that needs them.
         """
         logging.debug("Reconnecting to ZooKeeper")
-        for _, lock in list(self._locks.items()):
-            try:
-                if lock:
-                    lock.release()
-            except ZkClientError:
-                pass
-
-        self._locks = {}
+        self._drop_all_locks()
 
         connected = self._zk_client.reconnect()
 
@@ -573,7 +576,7 @@ class Zookeeper(object):
     def get_host_replics_info(self, hostname) -> list | None:
         return self.get(self._get_host_replics_info_path(hostname), preproc=json.loads)
 
-    def _get_host_wal_receiver_path(self, hostname):
+    def _get_host_wal_receiver_path(self, hostname=None):
         return helpers.get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
 
     def write_host_wal_receiver(self, wal_receiver_info, hostname=None) -> bool:

--- a/src/zk.py
+++ b/src/zk.py
@@ -156,6 +156,10 @@ class Zookeeper(object):
         lock = self._get_lock(name, read_lock)
         try:
             contenders = lock.contenders()
+        except ZkNoNodeError:
+            # Lock path does not exist yet — no contenders, proceed to acquire.
+            logging.debug('Lock "%s" path does not exist yet, no contenders', name)
+            contenders = []
         except ZkClientError:
             logging.exception('Failed to read contenders for lock "%s"', name)
             return False

--- a/src/zk.py
+++ b/src/zk.py
@@ -784,9 +784,12 @@ class Zookeeper(object):
         return result is not None
 
     def delete_host_ha(self, hostname=None) -> bool:
-        """Delete the ha node for a host. Returns False on failure."""
+        """Delete the ha node for a host. Returns True if path is absent or deleted."""
+        path = self.get_host_ha_path(hostname)
+        if not self.exists_path(path):
+            return True
         try:
-            self.delete(self.get_host_ha_path(hostname))
+            self.delete(path)
             return True
         except Exception:
             logging.exception('Failed to delete host ha path')
@@ -963,8 +966,8 @@ class Zookeeper(object):
             return False
 
     def get_last_failover_time(self) -> float | None:
-        """Get last failover timestamp."""
-        return self.get(self.LAST_FAILOVER_TIME_PATH, preproc=float)
+        """Get last failover timestamp. Returns None on ZK failure."""
+        return self.noexcept_get(self.LAST_FAILOVER_TIME_PATH, preproc=float)
 
     def write_last_failover_time(self) -> bool:
         """Write current time as last failover timestamp."""
@@ -1055,7 +1058,7 @@ class Zookeeper(object):
             try:
                 self.delete(path)
             except Exception:
-                logging.debug('Failed to delete switchover path: %s', path)
+                logging.exception('Failed to delete switchover path: %s', path)
 
     # === Timing methods ===
 

--- a/src/zk.py
+++ b/src/zk.py
@@ -916,7 +916,7 @@ class Zookeeper(object):
         return alive_hosts
 
 
-def create_zk(config: RawConfigParser, plugins, lock_contender_name=None) -> Zookeeper:
+def create_zk(config: RawConfigParser, lock_contender_name=None) -> Zookeeper:
     """Factory: build and connect a Zookeeper instance from config."""
     prefix = config.get('global', 'zk_lockpath_prefix')
     zk_config = ZookeeperConfig(
@@ -937,6 +937,5 @@ def create_zk(config: RawConfigParser, plugins, lock_contender_name=None) -> Zoo
 
     return Zookeeper(
         zk_client=zk_client,
-        plugins=plugins,
         config=zk_config,
     )

--- a/src/zk.py
+++ b/src/zk.py
@@ -767,12 +767,7 @@ class Zookeeper(object):
 
     def delete_host_op(self, hostname=None) -> bool:
         """Delete operation state for a host."""
-        try:
-            self.delete(self.get_host_op_path(hostname))
-            return True
-        except Exception:
-            logging.exception('Failed to delete host op path')
-            return False
+        return self.delete(self.get_host_op_path(hostname))
 
     def get_host_ha_path(self, hostname=None):
         """Return path to the ha node for the host."""
@@ -831,12 +826,7 @@ class Zookeeper(object):
 
     def delete_maintenance(self) -> bool:
         """Delete maintenance node and all its children."""
-        try:
-            self.delete(self.MAINTENANCE_PATH, recursive=True)
-            return True
-        except Exception:
-            logging.exception('Failed to delete maintenance path')
-            return False
+        return self.delete(self.MAINTENANCE_PATH, recursive=True)
 
     def get_maintenance_ts(self) -> str | None:
         """Get maintenance timestamp."""
@@ -924,12 +914,7 @@ class Zookeeper(object):
 
     def delete_failover_state(self) -> bool:
         """Delete failover state node."""
-        try:
-            self.delete(self.FAILOVER_STATE_PATH)
-            return True
-        except Exception:
-            logging.exception('Failed to delete failover state')
-            return False
+        return self.delete(self.FAILOVER_STATE_PATH)
 
     def write_current_promoting_host(self, hostname=None) -> bool:
         """Write current promoting host to ZooKeeper."""
@@ -944,12 +929,7 @@ class Zookeeper(object):
 
     def delete_current_promoting_host(self) -> bool:
         """Delete current promoting host node."""
-        try:
-            self.delete(self.CURRENT_PROMOTING_HOST)
-            return True
-        except Exception:
-            logging.exception('Failed to delete current promoting host')
-            return False
+        return self.delete(self.CURRENT_PROMOTING_HOST)
 
     def ensure_failover_must_be_reset(self) -> bool:
         """Ensure failover_must_be_reset flag exists."""
@@ -958,12 +938,7 @@ class Zookeeper(object):
 
     def delete_failover_must_be_reset(self) -> bool:
         """Delete failover_must_be_reset flag."""
-        try:
-            self.delete(self.FAILOVER_MUST_BE_RESET)
-            return True
-        except Exception:
-            logging.exception('Failed to delete failover_must_be_reset')
-            return False
+        return self.delete(self.FAILOVER_MUST_BE_RESET)
 
     def get_last_failover_time(self) -> float | None:
         """Get last failover timestamp. Returns None on ZK failure."""
@@ -1055,10 +1030,7 @@ class Zookeeper(object):
             self.FAILOVER_STATE_PATH,
         ]
         for path in paths_to_delete:
-            try:
-                self.delete(path)
-            except Exception:
-                logging.exception('Failed to delete switchover path: %s', path)
+            self.delete(path)
 
     # === Timing methods ===
 
@@ -1076,12 +1048,7 @@ class Zookeeper(object):
 
     def delete_timing(self, name: str) -> bool:
         """Delete timing node by name."""
-        try:
-            self.delete(self.get_timing_path(name), recursive=True)
-            return True
-        except Exception:
-            logging.exception('Failed to delete timing: %s', name)
-            return False
+        return self.delete(self.get_timing_path(name), recursive=True)
 
     def is_host_alive(self, hostname, timeout=0.0, catch_except=True):
         alive_path = self.get_host_alive_lock_path(hostname)

--- a/src/zk.py
+++ b/src/zk.py
@@ -6,6 +6,7 @@ Zookeeper wrapper module. Zookeeper class defined here.
 import json
 import logging
 import time
+from dataclasses import dataclass
 
 from . import helpers
 from .zk_client import (
@@ -21,16 +22,27 @@ from .zk_client import (
 )
 
 
-def create_zk(config, plugins, lock_contender_name=None):
+@dataclass
+class ZookeeperConfig:
+    release_lock_after_acquire_failed: bool
+    timeout: float
+    path_prefix: str
+    lock_contender_name: str | None = None
+
+
+def create_zk(config, plugins, lock_contender_name=None) -> Zookeeper:
     """Factory: build and connect a Zookeeper instance from config."""
-    release_lock_after_acquire_failed = config.getboolean('global', 'release_lock_after_acquire_failed')
-    timeout = config.getfloat('global', 'iteration_timeout')
     prefix = config.get('global', 'zk_lockpath_prefix')
-    path_prefix = prefix if prefix is not None else helpers.get_lockpath_prefix()
+    zk_config = ZookeeperConfig(
+        release_lock_after_acquire_failed=config.getboolean('global', 'release_lock_after_acquire_failed'),
+        timeout=config.getfloat('global', 'iteration_timeout'),
+        path_prefix=prefix if prefix is not None else helpers.get_lockpath_prefix(),
+        lock_contender_name=lock_contender_name,
+    )
 
     try:
         # Create and connect the client first (no listener yet — set after Zookeeper is constructed)
-        zk_client = create_zk_client(config, path_prefix=path_prefix)
+        zk_client = create_zk_client(config, path_prefix=zk_config.path_prefix)
         if not zk_client.init():
             raise Exception('Could not connect to ZK.')
     except Exception:
@@ -40,10 +52,7 @@ def create_zk(config, plugins, lock_contender_name=None):
     return Zookeeper(
         zk_client=zk_client,
         plugins=plugins,
-        release_lock_after_acquire_failed=release_lock_after_acquire_failed,
-        timeout=timeout,
-        path_prefix=path_prefix,
-        lock_contender_name=lock_contender_name,
+        config=zk_config,
     )
 
 
@@ -110,13 +119,10 @@ class Zookeeper(object):
     SSN_VALUE_PATH = f'{SSN_PATH}/value'
     SSN_DATE_PATH = f'{SSN_PATH}/last_update'
 
-    def __init__(self, zk_client, release_lock_after_acquire_failed, timeout, path_prefix, lock_contender_name=None):
-        self._lock_contender_name = lock_contender_name
-        self._release_lock_after_acquire_failed = release_lock_after_acquire_failed
-        self._timeout = timeout
-        self._locks = {}
-        self._path_prefix = path_prefix
-        self._lockpath = self._path_prefix + self.PRIMARY_LOCK_PATH
+    def __init__(self, zk_client: ZkClient, config: ZookeeperConfig):
+        self.config = config
+        self._locks: dict[str, LockHandle] = {}
+        self._lockpath = self.config.path_prefix + self.PRIMARY_LOCK_PATH
         self._zk_client = zk_client
         self._zk_client.set_state_listener(self._listener)
         self._init_lock(self.PRIMARY_LOCK_PATH)
@@ -132,9 +138,9 @@ class Zookeeper(object):
         self._locks = {}
         self._zk_client.close()
 
-    def get_lock_contender_name(self):
-        if self._lock_contender_name:
-            return self._lock_contender_name
+    def _get_lock_contender_name(self):
+        if self.config.lock_contender_name:
+            return self.config.lock_contender_name
         return helpers.get_hostname()
 
     def _listener(self, state: ZkConnectionState):
@@ -147,27 +153,24 @@ class Zookeeper(object):
         elif state == ZkConnectionState.CONNECTED:
             logging.info("Reconnected to ZK.")
 
-    def _get(self, path):
-        return self._zk_client.get(path)
-
     def _write(self, path, data, need_lock=True):
         # Each locked write checks lock ownership via a ZK round-trip (contenders()).
         # Local caching would risk stale state; the round-trip is intentional.
-        if need_lock and self.get_current_lock_holder() != self.get_lock_contender_name():
+        if need_lock and self.get_current_lock_holder() != self._get_lock_contender_name():
             return False
         return self._zk_client.write(path, data)
 
     def _init_lock(self, name, read_lock=False):
-        path = self._path_prefix + name
+        path = self.config.path_prefix + name
         if read_lock:
-            lock = self._zk_client.make_read_lock(path, self.get_lock_contender_name())
+            lock = self._zk_client.make_read_lock(path, self._get_lock_contender_name())
         else:
-            lock = self._zk_client.make_lock(path, self.get_lock_contender_name())
+            lock = self._zk_client.make_lock(path, self._get_lock_contender_name())
         self._locks[name] = lock
 
     def _acquire_lock(self, name, allow_queue, timeout, read_lock=False):
         if timeout is None:
-            timeout = self._timeout
+            timeout = self.config.timeout
         if not self._zk_client.is_connected():
             logging.warning('Not able to acquire %s ' % name + 'lock without alive connection.')
             return False
@@ -180,7 +183,7 @@ class Zookeeper(object):
         if len(contenders) != 0:
             if not read_lock:
                 contenders = contenders[:1]
-            if self.get_lock_contender_name() in contenders:
+            if self._get_lock_contender_name() in contenders:
                 logging.debug('We already hold the %s lock.', name)
                 return True
             if not (allow_queue or read_lock):
@@ -196,7 +199,7 @@ class Zookeeper(object):
         except ZkClientError:
             logging.exception('Unexpected error while acquiring lock "%s"', name)
             acquired = False
-        if not acquired and self._release_lock_after_acquire_failed:
+        if not acquired and self.config.release_lock_after_acquire_failed:
             logging.debug('Try to release and delete lock "%s", to recreate on next iter', name)
             try:
                 self.release_lock(name)
@@ -234,7 +237,7 @@ class Zookeeper(object):
         Other locks are re-acquired lazily on the next iteration that needs them.
         """
         logging.debug("Reconnecting to ZooKeeper")
-        for name, lock in list(self._locks.items()):
+        for _, lock in list(self._locks.items()):
             try:
                 if lock:
                     lock.release()
@@ -253,7 +256,7 @@ class Zookeeper(object):
     def get(self, key, preproc=None, debug=False):
         """Get key value from zk"""
         try:
-            res = self._get(key)
+            value = self._zk_client.get(key)
         except ZkNoNodeError:
             if debug:
                 logging.debug(f"NoNodeError when trying to get {key}")
@@ -263,7 +266,8 @@ class Zookeeper(object):
             raise ZookeeperException(exception)
         except ZkClientError as exception:
             raise ZookeeperException(exception)
-        value = res[0].decode('utf-8')
+        if value is None:
+            return None
         if preproc:
             try:
                 return preproc(value)
@@ -271,8 +275,7 @@ class Zookeeper(object):
                 if debug:
                     logging.debug(f"Failed to preproc {preproc.__name__} value {value} (key {key})")
                 return None
-        else:
-            return value
+        return value
 
     @helpers.return_none_on_error
     def noexcept_get(self, key, preproc=None):
@@ -280,21 +283,9 @@ class Zookeeper(object):
         return self.get(key, preproc)
 
     @helpers.return_none_on_error
-    def get_mtime(self, key):
+    def _get_mtime(self, key):
         """Returns modification time of ZK node"""
-        return getattr(self._get_meta(key), 'last_modified', None)
-
-    def _get_meta(self, key):
-        """Get metadata from key. Returns kazoo.protocol.states.ZnodeStat"""
-        try:
-            (_, meta) = self._get(key)
-        except ZkNoNodeError:
-            return None
-        except Exception:
-            logging.exception('Error getting node metadata for key: %s', key)
-            return None
-        else:
-            return meta
+        return self._zk_client.get_mtime(key)
 
     def ensure_path(self, path):
         """Check that path exists and create if not. Returns stat or None on error."""
@@ -336,7 +327,7 @@ class Zookeeper(object):
         data[self.FAILOVER_STATE_PATH] = self.get(self.FAILOVER_STATE_PATH)
         data[self.FAILOVER_MUST_BE_RESET] = self.exists_path(self.FAILOVER_MUST_BE_RESET)
         data[self.CURRENT_PROMOTING_HOST] = self.get(self.CURRENT_PROMOTING_HOST)
-        data['lock_version'] = self.get_current_lock_version()
+        data['lock_version'] = self._get_current_lock_version()
         data['lock_holder'] = self.get_current_lock_holder()
         data['single_node'] = self.exists_path(self.SINGLE_NODE_PATH)
         data[self.TIMELINE_INFO_PATH] = self.get(self.TIMELINE_INFO_PATH, preproc=int)
@@ -398,12 +389,9 @@ class Zookeeper(object):
         """Delete key from zk"""
         return self._zk_client.delete(key, recursive=recursive)
 
-    def get_current_lock_version(self):
+    def _get_current_lock_version(self):
         """Get current leader lock version"""
-        children = self.get_children(self._lockpath)
-        if children and len(children) > 0:
-            return min([i.split('__')[-1] for i in children])
-        return None
+        return self._zk_client.lock_version(self._lockpath)
 
     def get_lock_contenders(self, name, catch_except=True, read_lock=False):
         """Get all hostnames competing for the lock, including the holder."""
@@ -450,7 +438,7 @@ class Zookeeper(object):
             try:
                 self._release_lock(lock_type)
                 holder = self.get_current_lock_holder(name=lock_type)
-                if holder != self.get_lock_contender_name():
+                if holder != self._get_lock_contender_name():
                     return True
             except ZkConnectionClosedError:
                 self.reconnect()
@@ -463,32 +451,32 @@ class Zookeeper(object):
             holders = self.get_lock_contenders(lock_type, read_lock=read_lock)
         else:
             holders = [self.get_current_lock_holder(lock_type)]
-        if self.get_lock_contender_name() not in holders:
+        if self._get_lock_contender_name() not in holders:
             return True
         return self.release_lock(lock_type, wait)
 
     def get_host_alive_lock_path(self, hostname=None):
         return _get_host_path(self.HOST_ALIVE_LOCK_PATH, hostname)
 
-    def get_host_maintenance_path(self, hostname=None):
+    def _get_host_maintenance_path(self, hostname=None):
         return _get_host_path(self.HOST_MAINTENANCE_PATH, hostname)
 
     def get_host_quorum_path(self, hostname=None):
         return _get_host_path(self.QUORUM_MEMBER_LOCK_PATH, hostname)
 
-    def get_host_prio_path(self, hostname=None):
+    def _get_host_prio_path(self, hostname=None):
         return _get_host_path(self.HOST_PRIO_PATH, hostname)
 
-    def get_simple_primary_switch_try_path(self, hostname=None):
+    def _get_simple_primary_switch_try_path(self, hostname=None):
         return _get_host_path(self.SIMPLE_PRIMARY_SWITCH_TRY_PATH, hostname)
 
-    def get_ssn_value_path(self, hostname=None):
+    def _get_ssn_value_path(self, hostname=None):
         return _get_host_path(self.SSN_VALUE_PATH, hostname)
 
-    def get_ssn_date_path(self, hostname=None):
+    def _get_ssn_date_path(self, hostname=None):
         return _get_host_path(self.SSN_DATE_PATH, hostname)
 
-    def get_timing_path(self, timing_name):
+    def _get_timing_path(self, timing_name):
         return self.TIMINGS_PATH % timing_name
 
     def write_ssn_on_changes(self, value) -> bool:
@@ -498,8 +486,8 @@ class Zookeeper(object):
         """
         try:
             hostname = helpers.get_hostname()
-            value_path = self.get_ssn_value_path(hostname)
-            date_path = self.get_ssn_date_path(hostname)
+            value_path = self._get_ssn_value_path(hostname)
+            date_path = self._get_ssn_date_path(hostname)
 
             self.ensure_path(value_path)
             self.ensure_path(date_path)
@@ -513,10 +501,64 @@ class Zookeeper(object):
             logging.exception(exc)
             return False
 
-    def get_election_vote_path(self, hostname=None):
+    def _get_election_vote_path(self, hostname=None):
         if hostname is None:
             hostname = helpers.get_hostname()
         return self.ELECTION_VOTE_PATH % hostname
+
+    # === Election methods ===
+
+    def get_election_host_vote(self, hostname) -> tuple[int, int] | None:
+        """Returns (lsn, priority) for hostname's election vote, or None if unavailable."""
+        vote_path = self._get_election_vote_path(hostname)
+        lsn = self.get(vote_path + '/lsn', preproc=int, debug=True)
+        if lsn is None:
+            logging.error("Failed to get '%s' lsn for elections.", hostname)
+            return None
+        priority = self.get(vote_path + '/prio', preproc=int, debug=True)
+        if priority is None:
+            logging.error("Failed to get '%s' priority for elections.", hostname)
+            return None
+        return lsn, priority
+
+    def write_election_vote(self, lsn, prio) -> bool:
+        """Write current host's election vote (lsn and priority)."""
+        vote_path = self._get_election_vote_path()
+        if not self.ensure_path(vote_path):
+            return False
+        try:
+            self.write(vote_path + '/lsn', lsn, need_lock=False)
+            self.write(vote_path + '/prio', prio, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write election vote')
+            return False
+
+    def delete_election_vote(self, hostname) -> bool:
+        """Delete election vote node for hostname."""
+        return self.delete(self._get_election_vote_path(hostname), recursive=True)
+
+    def get_election_status(self) -> str | None:
+        return self.get(self.ELECTION_STATUS_PATH)
+
+    def write_election_status(self, status: str) -> bool:
+        try:
+            self.write(self.ELECTION_STATUS_PATH, status, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write election status')
+            return False
+
+    def get_election_winner(self) -> str | None:
+        return self.get(self.ELECTION_WINNER_PATH)
+
+    def write_election_winner(self, hostname: str) -> bool:
+        try:
+            self.write(self.ELECTION_WINNER_PATH, hostname, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write election winner')
+            return False
 
     def get_ha_hosts(self, catch_except=True):
         all_hosts = self.get_children(self.MEMBERS_PATH, catch_except=catch_except)
@@ -533,27 +575,27 @@ class Zookeeper(object):
 
     # === Host-level business methods ===
 
-    def get_host_op_path(self, hostname=None):
+    def _get_host_op_path(self, hostname=None):
         return _get_host_path(self.HOST_OP_PATH, hostname)
 
     def get_host_op(self, hostname=None):
-        return self.noexcept_get(self.get_host_op_path(hostname))
+        return self.noexcept_get(self._get_host_op_path(hostname))
 
     def write_host_op(self, op: str, hostname=None) -> bool:
-        return self.noexcept_write(self.get_host_op_path(hostname), op, need_lock=False)
+        return self.noexcept_write(self._get_host_op_path(hostname), op, need_lock=False)
 
     def delete_host_op(self, hostname=None) -> bool:
-        return self.delete(self.get_host_op_path(hostname))
+        return self.delete(self._get_host_op_path(hostname))
 
-    def get_host_ha_path(self, hostname=None):
+    def _get_host_ha_path(self, hostname=None):
         return _get_host_path(self.HOST_HA_PATH, hostname)
 
     def ensure_host_ha(self, hostname=None) -> bool:
-        result = self.ensure_path(self.get_host_ha_path(hostname))
+        result = self.ensure_path(self._get_host_ha_path(hostname))
         return result is not None
 
     def delete_host_ha(self, hostname=None) -> bool:
-        path = self.get_host_ha_path(hostname)
+        path = self._get_host_ha_path(hostname)
         if not self.exists_path(path):
             return True
         try:
@@ -563,32 +605,45 @@ class Zookeeper(object):
             logging.exception('Failed to delete host ha path')
             return False
 
-    def get_host_replics_info_path(self, hostname=None):
+    def _get_host_replics_info_path(self, hostname=None):
         return _get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)
 
     def write_host_replics_info(self, replics_info, hostname=None) -> bool:
         return self.noexcept_write(
-            self.get_host_replics_info_path(hostname), replics_info, preproc=json.dumps, need_lock=False
+            self._get_host_replics_info_path(hostname), replics_info, preproc=json.dumps, need_lock=False
         )
 
     def get_host_replics_info(self, hostname) -> list | None:
-        return self.get(self.get_host_replics_info_path(hostname), preproc=json.loads)
+        return self.get(self._get_host_replics_info_path(hostname), preproc=json.loads)
 
-    def get_host_wal_receiver_path(self, hostname):
+    def _get_host_wal_receiver_path(self, hostname):
         return _get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
 
     def write_host_wal_receiver(self, wal_receiver_info, hostname=None) -> bool:
         return self.noexcept_write(
-            self.get_host_wal_receiver_path(hostname), wal_receiver_info, preproc=json.dumps, need_lock=False
+            self._get_host_wal_receiver_path(hostname), wal_receiver_info, preproc=json.dumps, need_lock=False
         )
 
     def get_host_wal_receiver(self, hostname) -> dict | None:
-        return self.get(self.get_host_wal_receiver_path(hostname), preproc=json.loads)
+        return self.get(self._get_host_wal_receiver_path(hostname), preproc=json.loads)
 
     # === Maintenance methods ===
 
     def get_maintenance_status(self) -> str | None:
         return self.get(self.MAINTENANCE_PATH)
+
+    def write_maintenance_status(self, status: str) -> bool:
+        """Write maintenance status ('enable'/'disable') to the main maintenance path."""
+        try:
+            self.write(self.MAINTENANCE_PATH, status, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write maintenance status')
+            return False
+
+    def get_host_maintenance_status(self, hostname=None) -> str | None:
+        """Return the maintenance status string for a specific host."""
+        return self.get(self._get_host_maintenance_path(hostname))
 
     def delete_maintenance(self) -> bool:
         return self.delete(self.MAINTENANCE_PATH, recursive=True)
@@ -617,7 +672,7 @@ class Zookeeper(object):
 
     def write_host_maintenance_enabled(self, hostname=None) -> bool:
         try:
-            self.write(self.get_host_maintenance_path(hostname), 'enable', need_lock=False)
+            self.write(self._get_host_maintenance_path(hostname), 'enable', need_lock=False)
             return True
         except Exception:
             logging.exception('Failed to write host maintenance enabled')
@@ -710,7 +765,7 @@ class Zookeeper(object):
             logging.exception('Failed to write last primary availability time')
             return False
 
-    def get_last_switchover_time(self) -> float | None:
+    def _get_last_switchover_time(self) -> float | None:
         return self.get(self.LAST_SWITCHOVER_TIME_PATH, preproc=float)
 
     # === Switchover methods ===
@@ -737,7 +792,7 @@ class Zookeeper(object):
             logging.exception('Failed to write switchover candidate')
             return False
 
-    def get_switchover_candidate_host(self) -> str | None:
+    def _get_switchover_candidate_host(self) -> str | None:
         return self.get(self.SWITCHOVER_CANDIDATE)
 
     def write_switchover_side_replicas(self, replicas: list) -> bool:
@@ -771,17 +826,17 @@ class Zookeeper(object):
     # === Timing methods ===
 
     def get_timing(self, name: str) -> float | None:
-        return self.noexcept_get(self.get_timing_path(name), preproc=float)
+        return self.noexcept_get(self._get_timing_path(name), preproc=float)
 
     def write_timing(self, name: str, ts: float) -> None:
         try:
-            self.ensure_path(self.get_timing_path(name))
-            self.noexcept_write(self.get_timing_path(name), ts, need_lock=False)
+            self.ensure_path(self._get_timing_path(name))
+            self.noexcept_write(self._get_timing_path(name), ts, need_lock=False)
         except Exception:
             logging.exception('Failed to write timing: %s', name)
 
     def delete_timing(self, name: str) -> bool:
-        return self.delete(self.get_timing_path(name), recursive=True)
+        return self.delete(self._get_timing_path(name), recursive=True)
 
     def is_host_alive(self, hostname, timeout=0.0, catch_except=True):
         alive_path = self.get_host_alive_lock_path(hostname)
@@ -800,10 +855,102 @@ class Zookeeper(object):
             return []
         return [host for host in all_hosts if self._is_host_in_sync_quorum(host)]
 
+    def ensure_quorum_path(self) -> bool:
+        """Ensure the quorum path exists in ZK. Returns True on success."""
+        result = self.ensure_path(self.QUORUM_PATH)
+        return result is not None
+
+    def get_quorum(self) -> list | None:
+        """Return current quorum host list from ZK, or None on error."""
+        return self.get(self.QUORUM_PATH, preproc=helpers.load_json_or_default)
+
+    def write_quorum(self, hosts: list) -> bool:
+        """Persist quorum host list to ZK."""
+        try:
+            self.write(self.QUORUM_PATH, hosts, preproc=json.dumps, need_lock=False)
+            return True
+        except Exception:
+            logging.exception('Failed to write quorum')
+            return False
+
+    def clear_quorum(self) -> bool:
+        """Write empty list to quorum path."""
+        return self.write_quorum([])
+
     def get_quorum_replics_for_promote(self):
-        quorum = self.get(self.QUORUM_PATH, preproc=helpers.load_json_or_default) or []
+        quorum = self.get_quorum() or []
         my_hostname = helpers.get_hostname()
         return {h for h in quorum if h != my_hostname}
+
+    # === Members / host priority methods ===
+
+    def get_root_children(self) -> list | None:
+        """Return list of top-level nodes under the ZK path prefix."""
+        return self.get_children("")
+
+    def get_member_path(self, hostname: str) -> str:
+        """Return the ZK path for a cluster member."""
+        return f'{self.MEMBERS_PATH}/{hostname}'
+
+    def member_exists(self, hostname: str) -> bool:
+        """Return True if the member node exists in ZK."""
+        return self.exists_path(self.get_member_path(hostname))
+
+    def ensure_member(self, hostname: str) -> bool:
+        """Ensure the member node exists in ZK. Returns True on success."""
+        return self.ensure_path(self.get_member_path(hostname)) is not None
+
+    def get_members(self, catch_except=True) -> list | None:
+        """Return list of all cluster member hostnames."""
+        return self.get_children(self.MEMBERS_PATH, catch_except=catch_except)
+
+    def get_host_prio(self, hostname=None) -> str | None:
+        """Return stored priority value for hostname (current host if None)."""
+        return self.noexcept_get(self._get_host_prio_path(hostname))
+
+    def write_host_prio(self, prio, hostname=None) -> bool:
+        """Persist priority for hostname (current host if None)."""
+        return self.noexcept_write(self._get_host_prio_path(hostname), prio, need_lock=False)
+
+    # === Single-node status methods ===
+
+    def set_single_node(self) -> None:
+        """Mark cluster as single-node in ZK."""
+        self.ensure_path(self.SINGLE_NODE_PATH)
+
+    def clear_single_node(self) -> None:
+        """Remove single-node marker from ZK."""
+        self.delete(self.SINGLE_NODE_PATH)
+
+    # === Simple primary switch tracking ===
+
+    def get_simple_primary_switch_tried(self, hostname=None) -> bool:
+        """Return True if simple primary switch was already tried for hostname."""
+        return self.noexcept_get(self._get_simple_primary_switch_try_path(hostname)) == 'yes'
+
+    def set_simple_primary_switch_tried(self, hostname=None) -> None:
+        """Mark simple primary switch as tried for hostname."""
+        self.noexcept_write(self._get_simple_primary_switch_try_path(hostname), 'yes', need_lock=False)
+
+    def reset_simple_primary_switch_tried(self, hostname=None) -> None:
+        """Reset simple primary switch flag for hostname."""
+        if self.noexcept_get(self._get_simple_primary_switch_try_path(hostname)) != 'no':
+            self.noexcept_write(self._get_simple_primary_switch_try_path(hostname), 'no', need_lock=False)
+
+    # === Stream-source replica info ===
+
+    def get_stream_source_replics_info(self, stream_from: str) -> list | None:
+        """Return replics_info for a non-HA replica's stream source host."""
+        path = '{member_path}/{hostname}/replics_info'.format(
+            member_path=self.MEMBERS_PATH, hostname=stream_from
+        )
+        return self.noexcept_get(path, preproc=__import__('json').loads)
+
+    # === Legacy cleanup ===
+
+    def delete_legacy_timings_path(self) -> None:
+        """Delete mistakenly-created literal 'timing/%s' node."""
+        self.delete(self.TIMINGS_PATH)
 
     def get_alive_hosts(self, timeout=1, catch_except=True, all_hosts_timeout=None):
         ha_hosts = self.get_ha_hosts(catch_except=catch_except)

--- a/src/zk.py
+++ b/src/zk.py
@@ -6,6 +6,7 @@ Zookeeper wrapper module. Zookeeper class defined here.
 import json
 import logging
 import time
+from configparser import RawConfigParser
 from dataclasses import dataclass
 
 from . import helpers
@@ -28,38 +29,6 @@ class ZookeeperConfig:
     timeout: float
     path_prefix: str
     lock_contender_name: str | None = None
-
-
-def create_zk(config, plugins, lock_contender_name=None) -> Zookeeper:
-    """Factory: build and connect a Zookeeper instance from config."""
-    prefix = config.get('global', 'zk_lockpath_prefix')
-    zk_config = ZookeeperConfig(
-        release_lock_after_acquire_failed=config.getboolean('global', 'release_lock_after_acquire_failed'),
-        timeout=config.getfloat('global', 'iteration_timeout'),
-        path_prefix=prefix if prefix is not None else helpers.get_lockpath_prefix(),
-        lock_contender_name=lock_contender_name,
-    )
-
-    try:
-        # Create and connect the client first (no listener yet — set after Zookeeper is constructed)
-        zk_client = create_zk_client(config, path_prefix=zk_config.path_prefix)
-        if not zk_client.init():
-            raise Exception('Could not connect to ZK.')
-    except Exception:
-        logging.exception('Could not initialize ZooKeeper connection')
-        raise
-
-    return Zookeeper(
-        zk_client=zk_client,
-        plugins=plugins,
-        config=zk_config,
-    )
-
-
-def _get_host_path(path, hostname):
-    if hostname is None:
-        hostname = helpers.get_hostname()
-    return path % hostname
 
 
 class ZookeeperException(Exception):
@@ -282,11 +251,6 @@ class Zookeeper(object):
         """Get key value from zk, without ZK exception forwarding"""
         return self.get(key, preproc)
 
-    @helpers.return_none_on_error
-    def _get_mtime(self, key):
-        """Returns modification time of ZK node"""
-        return self._zk_client.get_mtime(key)
-
     def ensure_path(self, path):
         """Check that path exists and create if not. Returns stat or None on error."""
         try:
@@ -327,7 +291,7 @@ class Zookeeper(object):
         data[self.FAILOVER_STATE_PATH] = self.get(self.FAILOVER_STATE_PATH)
         data[self.FAILOVER_MUST_BE_RESET] = self.exists_path(self.FAILOVER_MUST_BE_RESET)
         data[self.CURRENT_PROMOTING_HOST] = self.get(self.CURRENT_PROMOTING_HOST)
-        data['lock_version'] = self._get_current_lock_version()
+        data['lock_version'] = self._zk_client.lock_version(self._lockpath)
         data['lock_holder'] = self.get_current_lock_holder()
         data['single_node'] = self.exists_path(self.SINGLE_NODE_PATH)
         data[self.TIMELINE_INFO_PATH] = self.get(self.TIMELINE_INFO_PATH, preproc=int)
@@ -353,8 +317,8 @@ class Zookeeper(object):
         if not all_hosts:
             return ssn_info
         for host in all_hosts:
-            path_value = _get_host_path(self.SSN_VALUE_PATH, host)
-            path_date = _get_host_path(self.SSN_DATE_PATH, host)
+            path_value = helpers.get_host_path(self.SSN_VALUE_PATH, host)
+            path_date = helpers.get_host_path(self.SSN_DATE_PATH, host)
             ssn_info[host] = (self.get(path_value), self.get(path_date))
         return ssn_info
 
@@ -388,10 +352,6 @@ class Zookeeper(object):
     def delete(self, key, recursive=False):
         """Delete key from zk"""
         return self._zk_client.delete(key, recursive=recursive)
-
-    def _get_current_lock_version(self):
-        """Get current leader lock version"""
-        return self._zk_client.lock_version(self._lockpath)
 
     def get_lock_contenders(self, name, catch_except=True, read_lock=False):
         """Get all hostnames competing for the lock, including the holder."""
@@ -456,25 +416,25 @@ class Zookeeper(object):
         return self.release_lock(lock_type, wait)
 
     def get_host_alive_lock_path(self, hostname=None):
-        return _get_host_path(self.HOST_ALIVE_LOCK_PATH, hostname)
+        return helpers.get_host_path(self.HOST_ALIVE_LOCK_PATH, hostname)
 
     def _get_host_maintenance_path(self, hostname=None):
-        return _get_host_path(self.HOST_MAINTENANCE_PATH, hostname)
+        return helpers.get_host_path(self.HOST_MAINTENANCE_PATH, hostname)
 
     def get_host_quorum_path(self, hostname=None):
-        return _get_host_path(self.QUORUM_MEMBER_LOCK_PATH, hostname)
+        return helpers.get_host_path(self.QUORUM_MEMBER_LOCK_PATH, hostname)
 
     def _get_host_prio_path(self, hostname=None):
-        return _get_host_path(self.HOST_PRIO_PATH, hostname)
+        return helpers.get_host_path(self.HOST_PRIO_PATH, hostname)
 
     def _get_simple_primary_switch_try_path(self, hostname=None):
-        return _get_host_path(self.SIMPLE_PRIMARY_SWITCH_TRY_PATH, hostname)
+        return helpers.get_host_path(self.SIMPLE_PRIMARY_SWITCH_TRY_PATH, hostname)
 
     def _get_ssn_value_path(self, hostname=None):
-        return _get_host_path(self.SSN_VALUE_PATH, hostname)
+        return helpers.get_host_path(self.SSN_VALUE_PATH, hostname)
 
     def _get_ssn_date_path(self, hostname=None):
-        return _get_host_path(self.SSN_DATE_PATH, hostname)
+        return helpers.get_host_path(self.SSN_DATE_PATH, hostname)
 
     def _get_timing_path(self, timing_name):
         return self.TIMINGS_PATH % timing_name
@@ -576,7 +536,7 @@ class Zookeeper(object):
     # === Host-level business methods ===
 
     def _get_host_op_path(self, hostname=None):
-        return _get_host_path(self.HOST_OP_PATH, hostname)
+        return helpers.get_host_path(self.HOST_OP_PATH, hostname)
 
     def get_host_op(self, hostname=None):
         return self.noexcept_get(self._get_host_op_path(hostname))
@@ -588,7 +548,7 @@ class Zookeeper(object):
         return self.delete(self._get_host_op_path(hostname))
 
     def _get_host_ha_path(self, hostname=None):
-        return _get_host_path(self.HOST_HA_PATH, hostname)
+        return helpers.get_host_path(self.HOST_HA_PATH, hostname)
 
     def ensure_host_ha(self, hostname=None) -> bool:
         result = self.ensure_path(self._get_host_ha_path(hostname))
@@ -606,7 +566,7 @@ class Zookeeper(object):
             return False
 
     def _get_host_replics_info_path(self, hostname=None):
-        return _get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)
+        return helpers.get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)
 
     def write_host_replics_info(self, replics_info, hostname=None) -> bool:
         return self.noexcept_write(
@@ -617,7 +577,7 @@ class Zookeeper(object):
         return self.get(self._get_host_replics_info_path(hostname), preproc=json.loads)
 
     def _get_host_wal_receiver_path(self, hostname):
-        return _get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
+        return helpers.get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
 
     def write_host_wal_receiver(self, wal_receiver_info, hostname=None) -> bool:
         return self.noexcept_write(
@@ -765,9 +725,6 @@ class Zookeeper(object):
             logging.exception('Failed to write last primary availability time')
             return False
 
-    def _get_last_switchover_time(self) -> float | None:
-        return self.get(self.LAST_SWITCHOVER_TIME_PATH, preproc=float)
-
     # === Switchover methods ===
 
     def get_switchover_state(self) -> str | None:
@@ -791,9 +748,6 @@ class Zookeeper(object):
         except Exception:
             logging.exception('Failed to write switchover candidate')
             return False
-
-    def _get_switchover_candidate_host(self) -> str | None:
-        return self.get(self.SWITCHOVER_CANDIDATE)
 
     def write_switchover_side_replicas(self, replicas: list) -> bool:
         try:
@@ -971,3 +925,29 @@ class Zookeeper(object):
                 timeout = all_hosts_timeout / len(ha_hosts)
         alive_hosts = [host for host in ha_hosts if self.is_host_alive(host, timeout, catch_except)]
         return alive_hosts
+
+
+def create_zk(config: RawConfigParser, plugins, lock_contender_name=None) -> Zookeeper:
+    """Factory: build and connect a Zookeeper instance from config."""
+    prefix = config.get('global', 'zk_lockpath_prefix')
+    zk_config = ZookeeperConfig(
+        release_lock_after_acquire_failed=config.getboolean('global', 'release_lock_after_acquire_failed'),
+        timeout=config.getfloat('global', 'iteration_timeout'),
+        path_prefix=prefix if prefix is not None else helpers.get_lockpath_prefix(),
+        lock_contender_name=lock_contender_name,
+    )
+
+    try:
+        # Create and connect the client first (no listener yet — set after Zookeeper is constructed)
+        zk_client = create_zk_client(config, path_prefix=zk_config.path_prefix)
+        if not zk_client.init():
+            raise Exception('Could not connect to ZK.')
+    except Exception:
+        logging.exception('Could not initialize ZooKeeper connection')
+        raise
+
+    return Zookeeper(
+        zk_client=zk_client,
+        plugins=plugins,
+        config=zk_config,
+    )

--- a/src/zk.py
+++ b/src/zk.py
@@ -293,7 +293,7 @@ class Zookeeper(object):
         data[self.CURRENT_PROMOTING_HOST] = self.get(self.CURRENT_PROMOTING_HOST)
         data['lock_version'] = self._zk_client.lock_version(self._lockpath)
         data['lock_holder'] = self.get_current_lock_holder()
-        data['single_node'] = self.exists_path(self.SINGLE_NODE_PATH)
+        data['single_node'] = self.is_single_node()
         data[self.TIMELINE_INFO_PATH] = self.get(self.TIMELINE_INFO_PATH, preproc=int)
         data[self.SWITCHOVER_ROOT_PATH] = self.get(self.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
         data[self.SWITCHOVER_CANDIDATE] = self.get(self.SWITCHOVER_CANDIDATE)
@@ -503,8 +503,7 @@ class Zookeeper(object):
 
     def write_election_status(self, status: str) -> bool:
         try:
-            self.write(self.ELECTION_STATUS_PATH, status, need_lock=False)
-            return True
+            return self.write(self.ELECTION_STATUS_PATH, status, need_lock=False)
         except Exception:
             logging.exception('Failed to write election status')
             return False
@@ -514,8 +513,7 @@ class Zookeeper(object):
 
     def write_election_winner(self, hostname: str) -> bool:
         try:
-            self.write(self.ELECTION_WINNER_PATH, hostname, need_lock=False)
-            return True
+            return self.write(self.ELECTION_WINNER_PATH, hostname, need_lock=False)
         except Exception:
             logging.exception('Failed to write election winner')
             return False
@@ -595,8 +593,7 @@ class Zookeeper(object):
     def write_maintenance_status(self, status: str) -> bool:
         """Write maintenance status ('enable'/'disable') to the main maintenance path."""
         try:
-            self.write(self.MAINTENANCE_PATH, status, need_lock=False)
-            return True
+            return self.write(self.MAINTENANCE_PATH, status, need_lock=False)
         except Exception:
             logging.exception('Failed to write maintenance status')
             return False
@@ -613,8 +610,7 @@ class Zookeeper(object):
 
     def write_maintenance_ts(self) -> bool:
         try:
-            self.write(self.MAINTENANCE_TIME_PATH, time.time(), need_lock=False)
-            return True
+            return self.write(self.MAINTENANCE_TIME_PATH, time.time(), need_lock=False)
         except Exception:
             logging.exception('Failed to write maintenance timestamp')
             return False
@@ -624,16 +620,14 @@ class Zookeeper(object):
 
     def write_maintenance_primary(self, primary_fqdn: str) -> bool:
         try:
-            self.write(self.MAINTENANCE_PRIMARY_PATH, primary_fqdn, need_lock=False)
-            return True
+            return self.write(self.MAINTENANCE_PRIMARY_PATH, primary_fqdn, need_lock=False)
         except Exception:
             logging.exception('Failed to write maintenance primary')
             return False
 
     def write_host_maintenance_enabled(self, hostname=None) -> bool:
         try:
-            self.write(self._get_host_maintenance_path(hostname), 'enable', need_lock=False)
-            return True
+            return self.write(self._get_host_maintenance_path(hostname), 'enable', need_lock=False)
         except Exception:
             logging.exception('Failed to write host maintenance enabled')
             return False
@@ -645,8 +639,7 @@ class Zookeeper(object):
 
     def write_timeline(self, timeline: int) -> bool:
         try:
-            self.write(self.TIMELINE_INFO_PATH, timeline)
-            return True
+            return self.write(self.TIMELINE_INFO_PATH, timeline)
         except Exception:
             logging.exception('Failed to write timeline')
             return False
@@ -661,8 +654,7 @@ class Zookeeper(object):
 
     def write_replics_info(self, replics_info) -> bool:
         try:
-            self.write(self.REPLICS_INFO_PATH, replics_info, preproc=json.dumps)
-            return True
+            return self.write(self.REPLICS_INFO_PATH, replics_info, preproc=json.dumps)
         except Exception:
             logging.exception('Failed to write replics_info')
             return False
@@ -674,8 +666,7 @@ class Zookeeper(object):
 
     def write_failover_state(self, state: str) -> bool:
         try:
-            self.write(self.FAILOVER_STATE_PATH, state)
-            return True
+            return self.write(self.FAILOVER_STATE_PATH, state)
         except Exception:
             logging.exception('Failed to write failover state')
             return False
@@ -687,8 +678,7 @@ class Zookeeper(object):
         try:
             if hostname is None:
                 hostname = helpers.get_hostname()
-            self.write(self.CURRENT_PROMOTING_HOST, hostname)
-            return True
+            return self.write(self.CURRENT_PROMOTING_HOST, hostname)
         except Exception:
             logging.exception('Failed to write current promoting host')
             return False
@@ -708,8 +698,7 @@ class Zookeeper(object):
 
     def write_last_failover_time(self) -> bool:
         try:
-            self.write(self.LAST_FAILOVER_TIME_PATH, time.time(), need_lock=False)
-            return True
+            return self.write(self.LAST_FAILOVER_TIME_PATH, time.time(), need_lock=False)
         except Exception:
             logging.exception('Failed to write last failover time')
             return False
@@ -719,8 +708,7 @@ class Zookeeper(object):
 
     def write_last_primary_availability_time(self) -> bool:
         try:
-            self.write(self.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
-            return True
+            return self.write(self.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
         except Exception:
             logging.exception('Failed to write last primary availability time')
             return False
@@ -732,8 +720,7 @@ class Zookeeper(object):
 
     def write_switchover_state(self, state: str) -> bool:
         try:
-            self.write(self.SWITCHOVER_STATE_PATH, state, need_lock=False)
-            return True
+            return self.write(self.SWITCHOVER_STATE_PATH, state, need_lock=False)
         except Exception:
             logging.exception('Failed to write switchover state')
             return False
@@ -743,24 +730,21 @@ class Zookeeper(object):
 
     def write_switchover_candidate(self, candidate: str) -> bool:
         try:
-            self.write(self.SWITCHOVER_CANDIDATE, candidate)
-            return True
+            return self.write(self.SWITCHOVER_CANDIDATE, candidate)
         except Exception:
             logging.exception('Failed to write switchover candidate')
             return False
 
     def write_switchover_side_replicas(self, replicas: list) -> bool:
         try:
-            self.write(self.SWITCHOVER_SIDE_REPLICAS, replicas, preproc=json.dumps)
-            return True
+            return self.write(self.SWITCHOVER_SIDE_REPLICAS, replicas, preproc=json.dumps)
         except Exception:
             logging.exception('Failed to write switchover side replicas')
             return False
 
     def write_last_switchover_time(self) -> bool:
         try:
-            self.write(self.LAST_SWITCHOVER_TIME_PATH, time.time(), need_lock=False)
-            return True
+            return self.write(self.LAST_SWITCHOVER_TIME_PATH, time.time(), need_lock=False)
         except Exception:
             logging.exception('Failed to write last switchover time')
             return False
@@ -821,8 +805,7 @@ class Zookeeper(object):
     def write_quorum(self, hosts: list) -> bool:
         """Persist quorum host list to ZK."""
         try:
-            self.write(self.QUORUM_PATH, hosts, preproc=json.dumps, need_lock=False)
-            return True
+            return self.write(self.QUORUM_PATH, hosts, preproc=json.dumps, need_lock=False)
         except Exception:
             logging.exception('Failed to write quorum')
             return False
@@ -868,6 +851,10 @@ class Zookeeper(object):
 
     # === Single-node status methods ===
 
+    def is_single_node(self) -> bool:
+        """Return True if the single-node marker exists in ZK."""
+        return self.exists_path(self.SINGLE_NODE_PATH)
+
     def set_single_node(self) -> None:
         """Mark cluster as single-node in ZK."""
         self.ensure_path(self.SINGLE_NODE_PATH)
@@ -898,7 +885,7 @@ class Zookeeper(object):
         path = '{member_path}/{hostname}/replics_info'.format(
             member_path=self.MEMBERS_PATH, hostname=stream_from
         )
-        return self.noexcept_get(path, preproc=__import__('json').loads)
+        return self.noexcept_get(path, preproc=json.loads)
 
     # === Legacy cleanup ===
 

--- a/src/zk.py
+++ b/src/zk.py
@@ -5,17 +5,46 @@ Zookeeper wrapper module. Zookeeper class defined here.
 
 import json
 import logging
-import os
 import time
-from random import uniform
-
-from kazoo.client import KazooClient, KazooState
-from kazoo.exceptions import LockTimeout, NoNodeError, KazooException, ConnectionClosedError, SessionExpiredError
-from kazoo.handlers.threading import KazooTimeoutError, SequentialThreadingHandler
-from kazoo.recipe.lock import Lock
-from kazoo.security import make_digest_acl
 
 from . import helpers
+from .zk_client import (
+    LockHandle,
+    ZkClient,
+    ZkClientError,
+    ZkConnectionClosedError,
+    ZkConnectionState,
+    ZkLockTimeout,
+    ZkNoNodeError,
+    ZkSessionExpiredError,
+    create_zk_client,
+)
+
+
+def create_zk(config, plugins, lock_contender_name=None):
+    """Factory: build and connect a Zookeeper instance from config."""
+    release_lock_after_acquire_failed = config.getboolean('global', 'release_lock_after_acquire_failed')
+    timeout = config.getfloat('global', 'iteration_timeout')
+    prefix = config.get('global', 'zk_lockpath_prefix')
+    path_prefix = prefix if prefix is not None else helpers.get_lockpath_prefix()
+
+    try:
+        # Create and connect the client first (no listener yet — set after Zookeeper is constructed)
+        zk_client = create_zk_client(config, path_prefix=path_prefix)
+        if not zk_client.init():
+            raise Exception('Could not connect to ZK.')
+    except Exception:
+        logging.exception('Could not initialize ZooKeeper connection')
+        raise
+
+    return Zookeeper(
+        zk_client=zk_client,
+        plugins=plugins,
+        release_lock_after_acquire_failed=release_lock_after_acquire_failed,
+        timeout=timeout,
+        path_prefix=path_prefix,
+        lock_contender_name=lock_contender_name,
+    )
 
 
 def _get_host_path(path, hostname):
@@ -50,11 +79,9 @@ class Zookeeper(object):
     LAST_SWITCHOVER_TIME_PATH = 'last_switchover_time'
     SWITCHOVER_ROOT_PATH = 'switchover'
     SWITCHOVER_LOCK_PATH = f'{SWITCHOVER_ROOT_PATH}/lock'
-    # A JSON string with primary fqmdn and its timeline
     SWITCHOVER_PRIMARY_PATH = f'{SWITCHOVER_ROOT_PATH}/master'
     SWITCHOVER_CANDIDATE = f'{SWITCHOVER_ROOT_PATH}/candidate'
     SWITCHOVER_SIDE_REPLICAS = f'{SWITCHOVER_ROOT_PATH}/side_replicas'
-    # A simple string with current scheduled switchover state
     SWITCHOVER_STATE_PATH = f'{SWITCHOVER_ROOT_PATH}/state'
     MAINTENANCE_PATH = 'maintenance'
     MAINTENANCE_TIME_PATH = f'{MAINTENANCE_PATH}/ts'
@@ -83,177 +110,73 @@ class Zookeeper(object):
     SSN_VALUE_PATH = f'{SSN_PATH}/value'
     SSN_DATE_PATH = f'{SSN_PATH}/last_update'
 
-    def __init__(self, config, lock_contender_name=None):
+    def __init__(self, zk_client, release_lock_after_acquire_failed, timeout, path_prefix, lock_contender_name=None):
         self._lock_contender_name = lock_contender_name
-        self._max_delay_on_reinit = config.getint('global', 'max_delay_on_zk_reinit')
-        self._base_delay = 3
-        self._failed_inits_count = 0
-        self._session_expired = False
-        self._zk_hosts = config.get('global', 'zk_hosts')
-        self._release_lock_after_acquire_failed = config.getboolean('global', 'release_lock_after_acquire_failed')
-        self._timeout = config.getfloat('global', 'iteration_timeout')
-        self._zk_connect_max_delay = config.getfloat('global', 'zk_connect_max_delay')
-        self._zk_auth = config.getboolean('global', 'zk_auth')
-        self._zk_ssl = config.getboolean('global', 'zk_ssl')
-        self._verify_certs = config.getboolean('global', 'verify_certs')
-        if self._zk_auth:
-            self._zk_username = config.get('global', 'zk_username')
-            self._zk_password = config.get('global', 'zk_password')
-            if not self._zk_username or not self._zk_password:
-                logging.error('zk_username, zk_password required when zk_auth enabled')
-        if self._zk_ssl:
-            self._cert = config.get('global', 'certfile')
-            self._key = config.get('global', 'keyfile')
-            self._ca = config.get('global', 'ca_cert')
-            if not self._cert or not self._key or not self._ca:
-                logging.error('certfile, keyfile, ca_cert required when zk_auth enabled')
-        try:
-            self._locks = {}
-            prefix = config.get('global', 'zk_lockpath_prefix')
-            self._path_prefix = prefix if prefix is not None else helpers.get_lockpath_prefix()
-            self._lockpath = self._path_prefix + self.PRIMARY_LOCK_PATH
+        self._release_lock_after_acquire_failed = release_lock_after_acquire_failed
+        self._timeout = timeout
+        self._locks = {}
+        self._path_prefix = path_prefix
+        self._lockpath = self._path_prefix + self.PRIMARY_LOCK_PATH
+        self._zk_client = zk_client
+        self._zk_client.set_state_listener(self._listener)
+        self._init_lock(self.PRIMARY_LOCK_PATH)
 
-            if not self._init_client():
-                raise Exception('Could not connect to ZK.')
-        except Exception:
-            logging.exception('Could not initialize ZooKeeper connection')
-
+    def close(self) -> None:
+        """Release all locks and close ZK connection."""
+        for lock in list(self._locks.values()):
+            try:
+                if lock:
+                    lock.release()
+            except Exception:
+                logging.debug("Error releasing lock during close", exc_info=True)
+        self._locks = {}
+        self._zk_client.close()
 
     def get_lock_contender_name(self):
         if self._lock_contender_name:
             return self._lock_contender_name
         return helpers.get_hostname()
 
-
-    def __del__(self):
-        self._zk.remove_listener(self._listener)
-        self._zk.stop()
-
-    def _create_kazoo_client(self):
-        """
-        Create Kazoo client with exponential backoff retry policy.
-        Connection retry uses exponential backoff to prevent overwhelming ZK during incidents.
-        """
-        # Exponential backoff for connection retries: 0.5s, 0.75s, 1.125s, ... up to max_delay
-        conn_retry_options = {
-            'max_tries': 3,
-            'delay': 0.5,
-            'backoff': 1.5,
-            'max_jitter': 0.9,
-            'max_delay': self._zk_connect_max_delay
-        }
-        # Disable command retries - let application handle it
-        command_retry_options = {
-            'max_tries': 0,
-            'delay': 0,
-            'backoff': 1,
-            'max_jitter': 0.9,
-            'max_delay': 5
-        }
-        args = {
-            'hosts': self._zk_hosts,
-            'handler': SequentialThreadingHandler(),
-            'timeout': self._timeout,
-            'connection_retry': conn_retry_options,
-            'command_retry': command_retry_options,
-        }
-        if self._zk_auth:
-            acl = make_digest_acl(self._zk_username, self._zk_password, all=True)
-            args.update(
-                {
-                    'default_acl': [acl],
-                    'auth_data': [
-                        (
-                            'digest',
-                            '{username}:{password}'.format(username=self._zk_username, password=self._zk_password),
-                        )
-                    ],
-                }
-            )
-        if self._zk_ssl:
-            args.update(
-                {
-                    'use_ssl': True,
-                    'certfile': self._cert,
-                    'keyfile': self._key,
-                    'ca': self._ca,
-                    'verify_certs': self._verify_certs,
-                }
-            )
-        self._zk = KazooClient(**args)
-
-    def _clear_connection_state_flags(self):
-        """
-        Clear session expired flag and failed inits counter
-        """
-        self._clear_session_expired_flag()
-        if self._failed_inits_count > 0:
-            logging.debug("Clearing failed_inits_count (was %d)", self._failed_inits_count)
-            self._failed_inits_count = 0
-
-    def _clear_session_expired_flag(self):
-        """
-        Clear session expired flag
-        """
-        if self._session_expired:
-            logging.debug("Clearing session expired flag")
-            self._session_expired = False
-
-    def _listener(self, state):
-        if state == KazooState.LOST:
-            # In the event that a LOST state occurs, its certain that the lock and/or the lease has been lost.
-            logging.error("Connection to ZK lost, clean all locks. (Kazoo)")
+    def _listener(self, state: ZkConnectionState):
+        """Business logic listener for ZkClient state changes."""
+        if state == ZkConnectionState.LOST:
+            logging.error("Connection to ZK lost, clean all locks.")
             self._locks = {}
-        elif state == KazooState.SUSPENDED:
-            logging.warning("Being disconnected from ZK. (Kazoo)")
-        elif state == KazooState.CONNECTED:
-            logging.info("Reconnected to ZK. (Kazoo)")
-            self._clear_connection_state_flags()
-
-    def _wait(self, event):
-        event.wait(self._timeout)
+        elif state == ZkConnectionState.SUSPENDED:
+            logging.warning("Being disconnected from ZK.")
+        elif state == ZkConnectionState.CONNECTED:
+            logging.info("Reconnected to ZK.")
 
     def _get(self, path):
-        event = self._zk.get_async(path)
-        self._wait(event)
-        return event.get_nowait()
+        return self._zk_client.get(path)
 
-    #
-    # We assume data is already converted to text.
-    #
     def _write(self, path, data, need_lock=True):
+        # Each locked write checks lock ownership via a ZK round-trip (contenders()).
+        # Local caching would risk stale state; the round-trip is intentional.
         if need_lock and self.get_current_lock_holder() != self.get_lock_contender_name():
             return False
-        event = self._zk.exists_async(path)
-        self._wait(event)
-        if event.get_nowait():  # Node exists
-            event = self._zk.set_async(path, data.encode())
-        else:
-            event = self._zk.create_async(path, value=data.encode())
-        self._wait(event)
-        # raise Timeout exception if set not done yet
-        event.get_nowait()
-        if event.exception:
-            logging.error('Failed to write to node: %s.' % path)
-            logging.error(event.exception)
-        return not event.exception
+        return self._zk_client.write(path, data)
 
     def _init_lock(self, name, read_lock=False):
         path = self._path_prefix + name
         if read_lock:
-            lock = self._zk.ReadLock(path, self.get_lock_contender_name())
+            lock = self._zk_client.make_read_lock(path, self.get_lock_contender_name())
         else:
-            lock = self._zk.Lock(path, self.get_lock_contender_name())
+            lock = self._zk_client.make_lock(path, self.get_lock_contender_name())
         self._locks[name] = lock
 
     def _acquire_lock(self, name, allow_queue, timeout, read_lock=False):
         if timeout is None:
             timeout = self._timeout
-        if self._zk.state != KazooState.CONNECTED:
+        if not self._zk_client.is_connected():
             logging.warning('Not able to acquire %s ' % name + 'lock without alive connection.')
             return False
         lock = self._get_lock(name, read_lock)
-        contenders = lock.contenders()
+        try:
+            contenders = lock.contenders()
+        except ZkClientError:
+            logging.exception('Failed to read contenders for lock "%s"', name)
+            return False
         if len(contenders) != 0:
             if not read_lock:
                 contenders = contenders[:1]
@@ -267,10 +190,10 @@ class Zookeeper(object):
             acquired = lock.acquire(blocking=True, timeout=timeout)
             if not acquired:
                 logging.warning('Unable to acquire lock "%s", but not because of timeout...', name)
-        except LockTimeout:
+        except ZkLockTimeout:
             logging.warning('Unable to obtain lock %s within timeout (%s s)', name, timeout)
             acquired = False
-        except Exception:
+        except ZkClientError:
             logging.exception('Unexpected error while acquiring lock "%s"', name)
             acquired = False
         if not acquired and self._release_lock_after_acquire_failed:
@@ -281,7 +204,7 @@ class Zookeeper(object):
                 logging.exception('Error releasing lock "%s" after failed acquire', name)
         return acquired
 
-    def _get_lock(self, name, read_lock) -> Lock:
+    def _get_lock(self, name, read_lock) -> LockHandle:
         if name in self._locks:
             return self._locks[name]
         else:
@@ -295,128 +218,50 @@ class Zookeeper(object):
 
     def _release_lock(self, name: str):
         if name in self._locks:
-            lock = self._locks[name] # type: Lock
+            lock = self._locks[name]
             self._delete_lock(name)
             return lock.release()
 
     def is_alive(self):
-        """
-        Return True if we are connected to zk
-        """
-        # Check real connection state first - if physically connected, clear expired flag
-        if self._zk.state == KazooState.CONNECTED:
-            # If we're physically connected, clear the session expired flag
-            if self._session_expired or self._failed_inits_count > 0:
-                logging.info("ZK connection restored")
-                self._clear_connection_state_flags()
-            return True
-
-        # If not connected, check if session was explicitly marked as expired
-        if self._session_expired:
-            logging.warning("ZK session was marked as expired, reconnection required")
-            return False
-
-        if self._zk.state == KazooState.SUSPENDED:
-            logging.warning("ZK connection SUSPENDED, will attempt reconnection on next iteration")
-        return False
-
-    def _sleep_before_reconnect(self):
-        """
-        Exponential backoff with jitter to prevent thundering herd problem.
-        Formula: random(0, min(base_delay * 2^attempt, max_delay))
-        """
-        max_sleep = min(self._base_delay * 2 ** self._failed_inits_count, self._max_delay_on_reinit)
-        sleep_time = uniform(0, max_sleep)
-        logging.warning(
-            "ZK reconnection attempt #%d failed. Applying exponential backoff: sleeping %.2fs "
-            "(max possible: %.2fs, configured max: %ds)",
-            self._failed_inits_count,
-            sleep_time,
-            max_sleep,
-            self._max_delay_on_reinit
-        )
-        time.sleep(sleep_time)
+        """Return True if we are connected to zk"""
+        return self._zk_client.is_alive()
 
     def reconnect(self):
-        """
-        Reconnect to ZooKeeper with exponential backoff.
-        Tracks failed attempts and increases delay between retries.
+        """Reconnect and restore locks.
+
+        Owns lock lifecycle: ZkClient.reconnect rebuilds the connection (backoff),
+        this method drops stale locks and re-inits only PRIMARY_LOCK_PATH.
+        Other locks are re-acquired lazily on the next iteration that needs them.
         """
         logging.debug("Reconnecting to ZooKeeper")
-        if self._failed_inits_count > 0:
-            self._sleep_before_reconnect()
-        try:
-            for lock in self._locks.items():
-                if lock[1]:
-                    lock[1].release()
-        except (KazooException, KazooTimeoutError):
-            pass
+        for name, lock in list(self._locks.items()):
+            try:
+                if lock:
+                    lock.release()
+            except ZkClientError:
+                pass
 
-        try:
-            self._locks = {}
-            self._zk.remove_listener(self._listener)
-            self._zk.stop()
-            self._zk.close()
-            connected = self._init_client() and self.is_alive()
-        except Exception:
-            logging.exception('Error during ZooKeeper reconnect')
-            connected = False
+        self._locks = {}
+
+        connected = self._zk_client.reconnect()
 
         if connected:
-            logging.info("Successfully reconnected to ZooKeeper")
-            self._clear_session_expired_flag()
-        else:
-            # Restore flag if reconnection failed
-            self._session_expired = True
-            self._failed_inits_count += 1
-            logging.error(
-                "Failed to reconnect to ZooKeeper (attempt #%d). "
-                "Next retry will use exponential backoff.",
-                self._failed_inits_count
-            )
+            self._init_lock(self.PRIMARY_LOCK_PATH)
+
         return connected
 
-    def _init_client(self) -> bool:
-        """
-        Initialize ZooKeeper client connection.
-        Returns True if successfully connected, False otherwise.
-        """
-        logging.debug("Initializing ZooKeeper client")
-        self._create_kazoo_client()
-        event = self._zk.start_async()
-        event.wait(self._timeout)
-        self._zk.add_listener(self._listener)
-
-        if not self._zk.connected:
-            logging.warning(
-                "ZooKeeper client failed to connect within timeout (%ds). "
-                "Hosts: %s",
-                self._timeout,
-                self._zk_hosts
-            )
-            return False
-
-        logging.info("Successfully connected to ZooKeeper: %s", self._zk_hosts)
-        self._init_lock(self.PRIMARY_LOCK_PATH)
-        return True
-
-
     def get(self, key, preproc=None, debug=False):
-        """
-        Get key value from zk
-        """
-        path = self._path_prefix + key
+        """Get key value from zk"""
         try:
-            res = self._get(path)
-        except NoNodeError:
+            res = self._get(key)
+        except ZkNoNodeError:
             if debug:
                 logging.debug(f"NoNodeError when trying to get {key}")
             return None
-        except SessionExpiredError as exception:
+        except ZkSessionExpiredError as exception:
             logging.error('ZK session expired during get operation')
-            self._session_expired = True
             raise ZookeeperException(exception)
-        except (KazooException, KazooTimeoutError) as exception:
+        except ZkClientError as exception:
             raise ZookeeperException(exception)
         value = res[0].decode('utf-8')
         if preproc:
@@ -431,86 +276,57 @@ class Zookeeper(object):
 
     @helpers.return_none_on_error
     def noexcept_get(self, key, preproc=None):
-        """
-        Get key value from zk, without ZK exception forwarding
-        """
+        """Get key value from zk, without ZK exception forwarding"""
         return self.get(key, preproc)
 
     @helpers.return_none_on_error
     def get_mtime(self, key):
-        """
-        Returns modification time of ZK node
-        """
+        """Returns modification time of ZK node"""
         return getattr(self._get_meta(key), 'last_modified', None)
 
     def _get_meta(self, key):
-        """
-        Get metadata from key.
-        returns kazoo.protocol.states.ZnodeStat
-        """
-        path = self._path_prefix + key
+        """Get metadata from key. Returns kazoo.protocol.states.ZnodeStat"""
         try:
-            (_, meta) = self._get(path)
-        except NoNodeError:
+            (_, meta) = self._get(key)
+        except ZkNoNodeError:
             return None
         except Exception:
-            logging.exception('Error getting node metadata for path: %s', path)
+            logging.exception('Error getting node metadata for key: %s', key)
             return None
         else:
             return meta
 
     def ensure_path(self, path):
-        """
-        Check that path exists and create if not
-        """
-        if not path.startswith(self._path_prefix):
-            path = os.path.join(self._path_prefix, path)
-        event = self._zk.ensure_path_async(path)
+        """Check that path exists and create if not. Returns stat or None on error."""
         try:
-            self._wait(event)
-            return event.get_nowait()
-        except (KazooException, KazooTimeoutError):
+            return self._zk_client.ensure_path(path)
+        except ZkClientError:
             logging.exception('Failed to ensure path: %s', path)
             return None
 
     def exists_path(self, path, catch_except=True):
-        if not path.startswith(self._path_prefix):
-            path = os.path.join(self._path_prefix, path)
-        event = self._zk.exists_async(path)
         try:
-            self._wait(event)
-            return bool(event.get_nowait())
-        except (KazooException, KazooTimeoutError) as e:
+            return self._zk_client.exists(path)
+        except ZkClientError as e:
             logging.exception('Error checking if path exists: %s', path)
             if not catch_except:
-                raise e
+                raise ZookeeperException(e)
             return False
 
     def get_children(self, path, catch_except=True):
-        """
-        Get children nodes of path
+        """Get children nodes of path.
+        Returns list ([] when node absent). Returns None / raises ZookeeperException on error.
         """
         try:
-            if not path.startswith(self._path_prefix):
-                path = os.path.join(self._path_prefix, path)
-            event = self._zk.get_children_async(path)
-            self._wait(event)
-            return event.get_nowait()
-        except NoNodeError as e:
-            logging.debug('No node found at path: %s', path, exc_info=True)
-            if not catch_except:
-                raise e
-            return None
-        except Exception as e:
+            return self._zk_client.get_children(path)
+        except ZkClientError as e:
             logging.exception('Error getting children of path: %s', path)
             if not catch_except:
-                raise e
+                raise ZookeeperException(e)
             return None
 
     def get_state(self):
-        """
-        Get current zk state (if possible)
-        """
+        """Get current zk state (if possible)"""
         data = {'alive': self.is_alive()}
         if not data['alive']:
             raise ZookeeperException("Zookeeper connection is unavailable now")
@@ -535,14 +351,16 @@ class Zookeeper(object):
         data[self.LAST_PRIMARY_PATH] = self.get(self.LAST_PRIMARY_PATH)
         data['synchronous_standby_names'] = self._get_ssn_info()
 
-        data['alive'] = self.is_alive()
-        if not data['alive']:
+        # Final liveness check: connection may have dropped during the reads above.
+        if not self.is_alive():
             raise ZookeeperException("Zookeeper connection is unavailable now")
         return data
 
-    def _get_ssn_info(self):
-        ssn_info = dict()
+    def _get_ssn_info(self) -> dict:
+        ssn_info: dict = {}
         all_hosts = self.get_children(self.MEMBERS_PATH, catch_except=True)
+        if not all_hosts:
+            return ssn_info
         for host in all_hosts:
             path_value = _get_host_path(self.SSN_VALUE_PATH, host)
             path_date = _get_host_path(self.SSN_DATE_PATH, host)
@@ -550,32 +368,26 @@ class Zookeeper(object):
         return ssn_info
 
     def _preproc_write(self, key, data, preproc):
-        path = self._path_prefix + key
         if preproc:
             sdata = preproc(data)
         else:
             sdata = str(data)
-        return path, sdata
+        return key, sdata
 
     def write(self, key, data, preproc=None, need_lock=True):
-        """
-        Write value to key in zk
-        """
-        path, sdata = self._preproc_write(key, data, preproc)
+        """Write value to key in zk"""
+        key, sdata = self._preproc_write(key, data, preproc)
         try:
-            return self._write(path, sdata, need_lock=need_lock)
-        except SessionExpiredError as exception:
+            return self._write(key, sdata, need_lock=need_lock)
+        except ZkSessionExpiredError as exception:
             logging.error('ZK session expired during write operation')
-            self._session_expired = True
             raise ZookeeperException(exception)
-        except (KazooException, KazooTimeoutError) as exception:
-            logging.exception('Failed to write zk node %s (data size: %d bytes): %s', path, len(sdata), sdata)
+        except ZkClientError as exception:
+            logging.exception('Failed to write zk node %s (data size: %d bytes): %s', key, len(sdata), sdata)
             raise ZookeeperException(exception)
 
     def noexcept_write(self, key, data, preproc=None, need_lock=True):
-        """
-        Write value to key in zk without zk exceptions forwarding
-        """
+        """Write value to key in zk without zk exceptions forwarding"""
         try:
             return self.write(key, data, preproc=preproc, need_lock=need_lock)
         except Exception:
@@ -583,34 +395,18 @@ class Zookeeper(object):
             return False
 
     def delete(self, key, recursive=False):
-        """
-        Delete key from zk
-        """
-        path = self._path_prefix + key
-        try:
-            self._zk.delete(path, recursive=recursive)
-            return True
-        except NoNodeError:
-            logging.info('No node %s was found in ZK to delete it.' % key)
-            return True
-        except Exception:
-            logging.exception('Error deleting ZK node: %s', key)
-            return False
+        """Delete key from zk"""
+        return self._zk_client.delete(key, recursive=recursive)
 
     def get_current_lock_version(self):
-        """
-        Get current leader lock version
-        """
+        """Get current leader lock version"""
         children = self.get_children(self._lockpath)
         if children and len(children) > 0:
             return min([i.split('__')[-1] for i in children])
         return None
 
     def get_lock_contenders(self, name, catch_except=True, read_lock=False):
-        """
-        Get a list of all hostnames that are competing for the lock,
-        including the holder.
-        """
+        """Get all hostnames competing for the lock, including the holder."""
         try:
             contenders = self._get_lock(name, read_lock).contenders()
             if len(contenders) > 0:
@@ -622,9 +418,7 @@ class Zookeeper(object):
         return []
 
     def get_current_lock_holder(self, name=None, catch_except=True):
-        """
-        Get hostname of lock holder
-        """
+        """Get hostname of lock holder"""
         name = name or self.PRIMARY_LOCK_PATH
         lock_contenders = self.get_lock_contenders(name, catch_except)
         if len(lock_contenders) > 0:
@@ -635,14 +429,11 @@ class Zookeeper(object):
     def acquire_lock(self, lock_type, allow_queue=False, timeout=None, read_lock=False):
         result = self._acquire_lock(lock_type, allow_queue, timeout, read_lock=read_lock)
         if not result:
-
             raise ZookeeperException(f'Failed to acquire lock {lock_type}')
         logging.debug(f'Success acquire lock: {lock_type}')
 
     def try_acquire_lock(self, lock_type=None, allow_queue=False, timeout=None, read_lock=False):
-        """
-        Acquire lock (leader by default)
-        """
+        """Acquire lock (leader by default)"""
         lock_type = lock_type or self.PRIMARY_LOCK_PATH
         acquired = self._acquire_lock(lock_type, allow_queue, timeout, read_lock=read_lock)
         if lock_type == self.PRIMARY_LOCK_PATH and acquired:
@@ -650,16 +441,10 @@ class Zookeeper(object):
         return acquired
 
     def release_lock(self, lock_type=None, wait=0):
-        """
-        Release lock (leader by default)
-        """
+        """Release lock (leader by default)"""
         lock_type = lock_type or self.PRIMARY_LOCK_PATH
-        # If caller decides to rely on kazoo internal API,
-        # release the lock and return immediately.
         if not wait:
             return self._release_lock(lock_type)
-
-        # Otherwise, make sure the lock is actually released.
 
         for _ in range(wait):
             try:
@@ -667,8 +452,7 @@ class Zookeeper(object):
                 holder = self.get_current_lock_holder(name=lock_type)
                 if holder != self.get_lock_contender_name():
                     return True
-            except ConnectionClosedError:
-                # ok, shit happens, now we should reconnect to ensure that we actually released the lock
+            except ZkConnectionClosedError:
                 self.reconnect()
             logging.warning('Unable to release lock "%s", retrying', lock_type)
             time.sleep(1)
@@ -709,12 +493,8 @@ class Zookeeper(object):
 
     def write_ssn_on_changes(self, value) -> bool:
         """
-        Persist *value* as the current SSN for this host in ZooKeeper.
-
-        Writes both the value node and the last-update timestamp node only when the stored
-        value differs from *value*.
-
-        Returns True on success, False on failure.
+        Persist value as the current SSN for this host in ZooKeeper.
+        Writes value and timestamp only when stored value differs.
         """
         try:
             hostname = helpers.get_hostname()
@@ -754,32 +534,25 @@ class Zookeeper(object):
     # === Host-level business methods ===
 
     def get_host_op_path(self, hostname=None):
-        """Return path to the op node for the host."""
         return _get_host_path(self.HOST_OP_PATH, hostname)
 
     def get_host_op(self, hostname=None):
-        """Get the current operation state for a host."""
         return self.noexcept_get(self.get_host_op_path(hostname))
 
     def write_host_op(self, op: str, hostname=None) -> bool:
-        """Write operation state for a host."""
         return self.noexcept_write(self.get_host_op_path(hostname), op, need_lock=False)
 
     def delete_host_op(self, hostname=None) -> bool:
-        """Delete operation state for a host."""
         return self.delete(self.get_host_op_path(hostname))
 
     def get_host_ha_path(self, hostname=None):
-        """Return path to the ha node for the host."""
         return _get_host_path(self.HOST_HA_PATH, hostname)
 
     def ensure_host_ha(self, hostname=None) -> bool:
-        """Ensure the ha node exists for a host. Returns True on success."""
         result = self.ensure_path(self.get_host_ha_path(hostname))
         return result is not None
 
     def delete_host_ha(self, hostname=None) -> bool:
-        """Delete the ha node for a host. Returns True if path is absent or deleted."""
         path = self.get_host_ha_path(hostname)
         if not self.exists_path(path):
             return True
@@ -791,49 +564,39 @@ class Zookeeper(object):
             return False
 
     def get_host_replics_info_path(self, hostname=None):
-        """Return path to the replics_info node for the host."""
         return _get_host_path(self.HOST_REPLICS_INFO_PATH, hostname)
 
     def write_host_replics_info(self, replics_info, hostname=None) -> bool:
-        """Write replics_info JSON for a host."""
         return self.noexcept_write(
             self.get_host_replics_info_path(hostname), replics_info, preproc=json.dumps, need_lock=False
         )
 
     def get_host_replics_info(self, hostname) -> list | None:
-        """Get replics_info JSON for a host."""
         return self.get(self.get_host_replics_info_path(hostname), preproc=json.loads)
 
     def get_host_wal_receiver_path(self, hostname):
-        """Return path to the wal_receiver node for the host."""
         return _get_host_path(self.HOST_WAL_RECEIVER_PATH, hostname)
 
     def write_host_wal_receiver(self, wal_receiver_info, hostname=None) -> bool:
-        """Write wal_receiver_info JSON for a host."""
         return self.noexcept_write(
             self.get_host_wal_receiver_path(hostname), wal_receiver_info, preproc=json.dumps, need_lock=False
         )
 
     def get_host_wal_receiver(self, hostname) -> dict | None:
-        """Get wal_receiver_info JSON for a host."""
         return self.get(self.get_host_wal_receiver_path(hostname), preproc=json.loads)
 
     # === Maintenance methods ===
 
     def get_maintenance_status(self) -> str | None:
-        """Get current maintenance status."""
         return self.get(self.MAINTENANCE_PATH)
 
     def delete_maintenance(self) -> bool:
-        """Delete maintenance node and all its children."""
         return self.delete(self.MAINTENANCE_PATH, recursive=True)
 
     def get_maintenance_ts(self) -> str | None:
-        """Get maintenance timestamp."""
         return self.get(self.MAINTENANCE_TIME_PATH)
 
     def write_maintenance_ts(self) -> bool:
-        """Write current time as maintenance timestamp."""
         try:
             self.write(self.MAINTENANCE_TIME_PATH, time.time(), need_lock=False)
             return True
@@ -842,11 +605,9 @@ class Zookeeper(object):
             return False
 
     def get_maintenance_primary(self) -> str | None:
-        """Get primary hostname that set maintenance."""
         return self.get(self.MAINTENANCE_PRIMARY_PATH)
 
     def write_maintenance_primary(self, primary_fqdn: str) -> bool:
-        """Write primary hostname that is setting maintenance."""
         try:
             self.write(self.MAINTENANCE_PRIMARY_PATH, primary_fqdn, need_lock=False)
             return True
@@ -855,7 +616,6 @@ class Zookeeper(object):
             return False
 
     def write_host_maintenance_enabled(self, hostname=None) -> bool:
-        """Write 'enable' to host maintenance path."""
         try:
             self.write(self.get_host_maintenance_path(hostname), 'enable', need_lock=False)
             return True
@@ -866,11 +626,9 @@ class Zookeeper(object):
     # === Timeline methods ===
 
     def get_timeline(self) -> int | None:
-        """Get current timeline from ZooKeeper."""
         return self.get(self.TIMELINE_INFO_PATH, preproc=int)
 
     def write_timeline(self, timeline: int) -> bool:
-        """Write timeline to ZooKeeper."""
         try:
             self.write(self.TIMELINE_INFO_PATH, timeline)
             return True
@@ -881,15 +639,12 @@ class Zookeeper(object):
     # === Global replics_info methods ===
 
     def get_replics_info(self) -> list | None:
-        """Get global replics_info list from ZooKeeper."""
         return self.get(self.REPLICS_INFO_PATH, preproc=json.loads)
 
     def noexcept_get_replics_info(self) -> list | None:
-        """Get global replics_info list without raising exceptions."""
         return self.noexcept_get(self.REPLICS_INFO_PATH, preproc=json.loads)
 
     def write_replics_info(self, replics_info) -> bool:
-        """Write global replics_info list to ZooKeeper."""
         try:
             self.write(self.REPLICS_INFO_PATH, replics_info, preproc=json.dumps)
             return True
@@ -900,11 +655,9 @@ class Zookeeper(object):
     # === Failover state methods ===
 
     def get_failover_state(self) -> str | None:
-        """Get current failover state."""
         return self.noexcept_get(self.FAILOVER_STATE_PATH)
 
     def write_failover_state(self, state: str) -> bool:
-        """Write failover state to ZooKeeper."""
         try:
             self.write(self.FAILOVER_STATE_PATH, state)
             return True
@@ -913,11 +666,9 @@ class Zookeeper(object):
             return False
 
     def delete_failover_state(self) -> bool:
-        """Delete failover state node."""
         return self.delete(self.FAILOVER_STATE_PATH)
 
     def write_current_promoting_host(self, hostname=None) -> bool:
-        """Write current promoting host to ZooKeeper."""
         try:
             if hostname is None:
                 hostname = helpers.get_hostname()
@@ -928,24 +679,19 @@ class Zookeeper(object):
             return False
 
     def delete_current_promoting_host(self) -> bool:
-        """Delete current promoting host node."""
         return self.delete(self.CURRENT_PROMOTING_HOST)
 
     def ensure_failover_must_be_reset(self) -> bool:
-        """Ensure failover_must_be_reset flag exists."""
         result = self.ensure_path(self.FAILOVER_MUST_BE_RESET)
         return result is not None
 
     def delete_failover_must_be_reset(self) -> bool:
-        """Delete failover_must_be_reset flag."""
         return self.delete(self.FAILOVER_MUST_BE_RESET)
 
     def get_last_failover_time(self) -> float | None:
-        """Get last failover timestamp. Returns None on ZK failure."""
         return self.noexcept_get(self.LAST_FAILOVER_TIME_PATH, preproc=float)
 
     def write_last_failover_time(self) -> bool:
-        """Write current time as last failover timestamp."""
         try:
             self.write(self.LAST_FAILOVER_TIME_PATH, time.time(), need_lock=False)
             return True
@@ -954,11 +700,9 @@ class Zookeeper(object):
             return False
 
     def get_last_primary_availability_time(self) -> float | None:
-        """Get last primary availability timestamp."""
         return self.noexcept_get(self.LAST_PRIMARY_AVAILABILITY_TIME, preproc=float)
 
     def write_last_primary_availability_time(self) -> bool:
-        """Write current time as last primary availability timestamp."""
         try:
             self.write(self.LAST_PRIMARY_AVAILABILITY_TIME, time.time())
             return True
@@ -967,17 +711,14 @@ class Zookeeper(object):
             return False
 
     def get_last_switchover_time(self) -> float | None:
-        """Get last switchover timestamp."""
         return self.get(self.LAST_SWITCHOVER_TIME_PATH, preproc=float)
 
     # === Switchover methods ===
 
     def get_switchover_state(self) -> str | None:
-        """Get current switchover state."""
         return self.get(self.SWITCHOVER_STATE_PATH)
 
     def write_switchover_state(self, state: str) -> bool:
-        """Write switchover state to ZooKeeper."""
         try:
             self.write(self.SWITCHOVER_STATE_PATH, state, need_lock=False)
             return True
@@ -986,11 +727,9 @@ class Zookeeper(object):
             return False
 
     def get_switchover_primary_info(self) -> dict | None:
-        """Get switchover primary info (JSON with fqdn and timeline)."""
         return self.get(self.SWITCHOVER_PRIMARY_PATH, preproc=json.loads)
 
     def write_switchover_candidate(self, candidate: str) -> bool:
-        """Write switchover candidate hostname."""
         try:
             self.write(self.SWITCHOVER_CANDIDATE, candidate)
             return True
@@ -999,11 +738,9 @@ class Zookeeper(object):
             return False
 
     def get_switchover_candidate_host(self) -> str | None:
-        """Get switchover candidate hostname."""
         return self.get(self.SWITCHOVER_CANDIDATE)
 
     def write_switchover_side_replicas(self, replicas: list) -> bool:
-        """Write switchover side replicas list."""
         try:
             self.write(self.SWITCHOVER_SIDE_REPLICAS, replicas, preproc=json.dumps)
             return True
@@ -1012,7 +749,6 @@ class Zookeeper(object):
             return False
 
     def write_last_switchover_time(self) -> bool:
-        """Write current time as last switchover timestamp."""
         try:
             self.write(self.LAST_SWITCHOVER_TIME_PATH, time.time(), need_lock=False)
             return True
@@ -1035,11 +771,9 @@ class Zookeeper(object):
     # === Timing methods ===
 
     def get_timing(self, name: str) -> float | None:
-        """Get timing value by name."""
         return self.noexcept_get(self.get_timing_path(name), preproc=float)
 
     def write_timing(self, name: str, ts: float) -> None:
-        """Write timing value. Ensures path exists before writing."""
         try:
             self.ensure_path(self.get_timing_path(name))
             self.noexcept_write(self.get_timing_path(name), ts, need_lock=False)
@@ -1047,7 +781,6 @@ class Zookeeper(object):
             logging.exception('Failed to write timing: %s', name)
 
     def delete_timing(self, name: str) -> bool:
-        """Delete timing node by name."""
         return self.delete(self.get_timing_path(name), recursive=True)
 
     def is_host_alive(self, hostname, timeout=0.0, catch_except=True):
@@ -1080,10 +813,13 @@ class Zookeeper(object):
             minimal_total_timeout = timeout * len(ha_hosts)
             if minimal_total_timeout > all_hosts_timeout:
                 logging.warning("Expected timeout for checking host aliveness will be ignored.")
-                logging.debug("The minimal total timeout for checking the aliveness of all hosts (%s s) "
-                                "is greater than the expected one - all_hosts_timeout (%s s)."
-                                "Consider increasing the election timeout.",
-                                minimal_total_timeout, all_hosts_timeout)
+                logging.debug(
+                    "The minimal total timeout for checking the aliveness of all hosts (%s s) "
+                    "is greater than the expected one - all_hosts_timeout (%s s)."
+                    "Consider increasing the election timeout.",
+                    minimal_total_timeout,
+                    all_hosts_timeout,
+                )
             else:
                 timeout = all_hosts_timeout / len(ha_hosts)
         alive_hosts = [host for host in ha_hosts if self.is_host_alive(host, timeout, catch_except)]

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -1,0 +1,450 @@
+# encoding: utf-8
+"""
+ZkClient module. Low-level KazooClient wrapper for ZooKeeper connection management.
+"""
+
+import logging
+import os
+import time
+from enum import Enum
+from random import uniform
+from typing import Callable, List, Optional
+
+from kazoo.client import KazooClient, KazooState
+from kazoo.exceptions import (
+    ConnectionClosedError,
+    KazooException,
+    LockTimeout,
+    NodeExistsError,
+    NoNodeError,
+    SessionExpiredError,
+)
+from kazoo.handlers.threading import KazooTimeoutError, SequentialThreadingHandler
+from kazoo.security import make_digest_acl
+
+
+# === Domain exceptions ===
+
+class ZkClientError(Exception):
+    """Base ZkClient error; wraps all transport-level failures."""
+
+
+class ZkSessionExpiredError(ZkClientError):
+    """ZK session expired."""
+
+
+class ZkNoNodeError(ZkClientError):
+    """Requested ZK node does not exist."""
+
+
+class ZkConnectionClosedError(ZkClientError):
+    """ZK connection was closed."""
+
+
+class ZkLockTimeout(ZkClientError):
+    """Lock acquisition timed out."""
+
+
+# === Connection state ===
+
+class ZkConnectionState(Enum):
+    CONNECTED = 'connected'
+    SUSPENDED = 'suspended'
+    LOST = 'lost'
+
+
+_KAZOO_STATE_MAP = {
+    KazooState.CONNECTED: ZkConnectionState.CONNECTED,
+    KazooState.SUSPENDED: ZkConnectionState.SUSPENDED,
+    KazooState.LOST: ZkConnectionState.LOST,
+}
+
+
+# === Lock handle ===
+
+class LockHandle:
+    """Wraps a kazoo lock; translates exceptions to domain types."""
+
+    def __init__(self, lock):
+        self._lock = lock
+
+    def acquire(self, blocking=True, timeout=None) -> bool:
+        try:
+            return self._lock.acquire(blocking=blocking, timeout=timeout)
+        except LockTimeout as e:
+            raise ZkLockTimeout(e)
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def release(self):
+        try:
+            return self._lock.release()
+        except ConnectionClosedError as e:
+            raise ZkConnectionClosedError(e)
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def contenders(self):
+        try:
+            return self._lock.contenders()
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+
+def create_zk_client(config, state_listener=None, path_prefix=None):
+    """Factory: create ZkClient from config object."""
+    zk_hosts = config.get('global', 'zk_hosts')
+    timeout = config.getfloat('global', 'iteration_timeout')
+    connect_max_delay = config.getfloat('global', 'zk_connect_max_delay')
+    max_delay_on_reinit = config.getint('global', 'max_delay_on_zk_reinit')
+    zk_auth = config.getboolean('global', 'zk_auth')
+    zk_ssl = config.getboolean('global', 'zk_ssl')
+    verify_certs = config.getboolean('global', 'verify_certs')
+
+    zk_username = None
+    zk_password = None
+    if zk_auth:
+        zk_username = config.get('global', 'zk_username')
+        zk_password = config.get('global', 'zk_password')
+        if not zk_username or not zk_password:
+            logging.error('zk_username, zk_password required when zk_auth enabled')
+
+    cert = None
+    key = None
+    ca = None
+    if zk_ssl:
+        cert = config.get('global', 'certfile')
+        key = config.get('global', 'keyfile')
+        ca = config.get('global', 'ca_cert')
+        if not cert or not key or not ca:
+            logging.error('certfile, keyfile, ca_cert required when zk_ssl enabled')
+
+    if path_prefix is None:
+        from . import helpers
+        path_prefix = helpers.get_lockpath_prefix()
+
+    return ZkClient(
+        hosts=zk_hosts,
+        timeout=timeout,
+        connect_max_delay=connect_max_delay,
+        max_delay_on_reinit=max_delay_on_reinit,
+        auth=zk_auth,
+        username=zk_username,
+        password=zk_password,
+        ssl=zk_ssl,
+        cert=cert,
+        key=key,
+        ca=ca,
+        verify_certs=verify_certs,
+        state_listener=state_listener,
+        path_prefix=path_prefix,
+    )
+
+
+class ZkClient(object):
+    """
+    Low-level ZooKeeper client wrapper.
+    Manages KazooClient lifecycle, reconnection with exponential backoff,
+    and sync data operations with path_prefix support.
+
+    All data methods raise domain exceptions (ZkClientError hierarchy)
+    instead of raw kazoo exceptions.
+    """
+
+    def __init__(
+        self,
+        hosts,
+        timeout,
+        connect_max_delay,
+        max_delay_on_reinit,
+        auth=False,
+        username=None,
+        password=None,
+        ssl=False,
+        cert=None,
+        key=None,
+        ca=None,
+        verify_certs=True,
+        state_listener: Optional[Callable] = None,
+        path_prefix='/pgconsul/',
+    ):
+        self._hosts = hosts
+        self._timeout = timeout
+        self._connect_max_delay = connect_max_delay
+        self._max_delay_on_reinit = max_delay_on_reinit
+        self._auth = auth
+        self._username = username
+        self._password = password
+        self._ssl = ssl
+        self._cert = cert
+        self._key = key
+        self._ca = ca
+        self._verify_certs = verify_certs
+        self._path_prefix = path_prefix
+
+        self._base_delay = 3
+        self._failed_inits_count = 0
+        self._session_expired = False
+
+        self._state_listener: Optional[Callable] = state_listener
+        # Assigned by _create_kazoo_client() before any data method is called.
+        self._kazoo: Optional[KazooClient] = None
+
+    @property
+    def _client(self) -> KazooClient:
+        """Live KazooClient; raises if accessed before init()."""
+        assert self._kazoo is not None, "Kazoo client is not initialized"
+        return self._kazoo
+
+    def set_state_listener(self, listener: Callable) -> None:
+        """Register or replace the external state-change callback."""
+        self._state_listener = listener
+
+    def init(self) -> bool:
+        """Connect to ZK. Returns True on success."""
+        logging.debug("Initializing ZooKeeper client")
+        self._create_kazoo_client()
+        event = self._client.start_async()
+        event.wait(self._timeout)
+        self._client.add_listener(self._listener)
+
+        if not self._client.connected:
+            logging.warning(
+                "ZooKeeper client failed to connect within timeout (%ds). Hosts: %s",
+                self._timeout,
+                self._hosts,
+            )
+            return False
+
+        logging.info("Successfully connected to ZooKeeper: %s", self._hosts)
+        return True
+
+    def reconnect(self) -> bool:
+        """Rebuild the connection with exponential backoff. Returns True on success.
+
+        Connection-only: does not touch locks (owned by Zookeeper.reconnect).
+        """
+        logging.debug("Reconnecting to ZooKeeper")
+        if self._failed_inits_count > 0:
+            self._sleep_before_reconnect()
+
+        try:
+            self._client.remove_listener(self._listener)
+            self._client.stop()
+            self._client.close()
+            # Use is_connected() (pure state check) — after a fresh init the
+            # session is brand new, so _session_expired must not block the check.
+            connected = self.init() and self.is_connected()
+        except Exception:
+            logging.exception('Error during ZooKeeper reconnect')
+            connected = False
+
+        if connected:
+            logging.info("Successfully reconnected to ZooKeeper")
+            self._clear_session_expired_flag()
+        else:
+            self._session_expired = True
+            self._failed_inits_count += 1
+            logging.error(
+                "Failed to reconnect to ZooKeeper (attempt #%d).",
+                self._failed_inits_count,
+            )
+        return connected
+
+    def is_alive(self) -> bool:
+        """True if connected and session healthy. Pure query — no side effects."""
+        if self._session_expired:
+            return False
+        return self._client.state == KazooState.CONNECTED
+
+    def is_connected(self) -> bool:
+        """Pure state check: True iff KazooState == CONNECTED. No side effects."""
+        return self._client.state == KazooState.CONNECTED
+
+    def close(self) -> None:
+        """Explicit shutdown: remove listener, stop and close Kazoo."""
+        if self._kazoo is None:
+            return
+        try:
+            self._kazoo.remove_listener(self._listener)
+        except Exception:
+            logging.debug("Error removing listener during close", exc_info=True)
+        try:
+            self._kazoo.stop()
+            self._kazoo.close()
+        except Exception:
+            logging.debug("Error stopping Kazoo during close", exc_info=True)
+
+    def _create_kazoo_client(self):
+        conn_retry_options = {
+            'max_tries': 3,
+            'delay': 0.5,
+            'backoff': 1.5,
+            'max_jitter': 0.9,
+            'max_delay': self._connect_max_delay,
+        }
+        command_retry_options = {
+            'max_tries': 0,
+            'delay': 0,
+            'backoff': 1,
+            'max_jitter': 0.9,
+            'max_delay': 5,
+        }
+        args = {
+            'hosts': self._hosts,
+            'handler': SequentialThreadingHandler(),
+            'timeout': self._timeout,
+            'connection_retry': conn_retry_options,
+            'command_retry': command_retry_options,
+        }
+        if self._auth:
+            acl = make_digest_acl(self._username, self._password, all=True)
+            args.update(
+                {
+                    'default_acl': [acl],
+                    'auth_data': [
+                        ('digest', '{username}:{password}'.format(username=self._username, password=self._password)),
+                    ],
+                }
+            )
+        if self._ssl:
+            args.update(
+                {
+                    'use_ssl': True,
+                    'certfile': self._cert,
+                    'keyfile': self._key,
+                    'ca': self._ca,
+                    'verify_certs': self._verify_certs,
+                }
+            )
+        self._kazoo = KazooClient(**args)
+
+    def _listener(self, state):
+        """Internal Kazoo listener: update session flags first, then notify Zookeeper.
+
+        Order matters: own flags settle before the domain callback reacts (drops locks).
+        """
+        if state == KazooState.LOST:
+            self._session_expired = True
+        elif state == KazooState.CONNECTED:
+            self._clear_connection_state_flags()
+
+        if self._state_listener:
+            domain_state = _KAZOO_STATE_MAP.get(state)
+            if domain_state is not None:
+                self._state_listener(domain_state)
+
+    def _sleep_before_reconnect(self):
+        """Exponential backoff with jitter."""
+        max_sleep = min(self._base_delay * 2 ** self._failed_inits_count, self._max_delay_on_reinit)
+        sleep_time = uniform(0, max_sleep)
+        logging.warning(
+            "ZK reconnection attempt #%d. Sleeping %.2fs (max: %.2fs, configured max: %ds)",
+            self._failed_inits_count,
+            sleep_time,
+            max_sleep,
+            self._max_delay_on_reinit,
+        )
+        time.sleep(sleep_time)
+
+    def _clear_connection_state_flags(self):
+        self._clear_session_expired_flag()
+        if self._failed_inits_count > 0:
+            logging.debug("Clearing failed_inits_count (was %d)", self._failed_inits_count)
+            self._failed_inits_count = 0
+
+    def _clear_session_expired_flag(self):
+        if self._session_expired:
+            logging.debug("Clearing session expired flag")
+            self._session_expired = False
+
+    def _resolve_path(self, path):
+        if not path.startswith(self._path_prefix):
+            return os.path.join(self._path_prefix, path)
+        return path
+
+    # === Data operations ===
+
+    def get(self, path):
+        """Return (data, stat). Raises ZkNoNodeError, ZkSessionExpiredError, ZkClientError."""
+        try:
+            return self._client.get(self._resolve_path(path))
+        except NoNodeError as e:
+            raise ZkNoNodeError(e)
+        except SessionExpiredError as e:
+            raise ZkSessionExpiredError(e)
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def write(self, path, data):
+        """
+        Atomic write: set → create → set on race.
+        Returns True. Raises ZkSessionExpiredError, ZkClientError on failure.
+        """
+        full_path = self._resolve_path(path)
+        encoded = data.encode()
+        try:
+            try:
+                self._client.set(full_path, encoded)
+            except NoNodeError:
+                try:
+                    self._client.create(full_path, value=encoded, makepath=True)
+                except NodeExistsError:
+                    self._client.set(full_path, encoded)
+            return True
+        except SessionExpiredError as e:
+            raise ZkSessionExpiredError(e)
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def ensure_path(self, path):
+        """Ensure path exists. Returns stat. Raises ZkClientError on failure."""
+        full_path = self._resolve_path(path)
+        try:
+            return self._client.ensure_path(full_path)
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def exists(self, path):
+        """
+        Return True if path exists, False if absent.
+        Raises ZkClientError on connection failure.
+        """
+        try:
+            return bool(self._client.exists(self._resolve_path(path)))
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def get_children(self, path) -> List[str]:
+        """
+        Return list of children ([] if node absent).
+        Raises ZkClientError on connection failure.
+        """
+        full_path = self._resolve_path(path)
+        try:
+            return self._client.get_children(full_path)
+        except NoNodeError:
+            logging.debug('No node found at path: %s', full_path, exc_info=True)
+            return []
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def delete(self, path, recursive=False):
+        """Delete path. Returns True (including when absent). Raises ZkClientError on error."""
+        full_path = self._resolve_path(path)
+        try:
+            self._client.delete(full_path, recursive=recursive)
+            return True
+        except NoNodeError:
+            logging.info('No node %s was found in ZK to delete it.', full_path)
+            return True
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    # === Lock recipes ===
+
+    def make_lock(self, path, identifier) -> LockHandle:
+        return LockHandle(self._client.Lock(path, identifier))
+
+    def make_read_lock(self, path, identifier) -> LockHandle:
+        return LockHandle(self._client.ReadLock(path, identifier))

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -81,6 +81,11 @@ class LockHandle:
     def release(self):
         try:
             return self._lock.release()
+        except NoNodeError:
+            # Node already removed (e.g. ZK cleaned up ephemeral after session expiry).
+            # Releasing a non-existent lock node is a success — the lock is already gone.
+            logging.debug("Lock node already gone during release, treating as success")
+            return True
         except ConnectionClosedError as e:
             raise ZkConnectionClosedError(e)
         except (KazooException, KazooTimeoutError) as e:
@@ -89,6 +94,8 @@ class LockHandle:
     def contenders(self):
         try:
             return self._lock.contenders()
+        except NoNodeError as e:
+            raise ZkNoNodeError(e)
         except (KazooException, KazooTimeoutError) as e:
             raise ZkClientError(e)
 

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -165,18 +165,7 @@ class ZkClient(object):
     instead of raw kazoo exceptions.
     """
 
-    def __init__(self, config: ZkClientConfig = None, state_listener: Optional[Callable] = None, **kwargs):
-        if config is None:
-            # Support flat kwargs for backwards compatibility
-            config = ZkClientConfig(
-                hosts=kwargs['hosts'],
-                timeout=kwargs['timeout'],
-                connect_max_delay=kwargs['connect_max_delay'],
-                max_delay_on_reinit=kwargs['max_delay_on_reinit'],
-                path_prefix=kwargs.get('path_prefix', ''),
-                auth=kwargs.get('auth', False),
-                ssl=kwargs.get('ssl', False),
-            )
+    def __init__(self, config: ZkClientConfig, state_listener: Optional[Callable] = None):
         self.config = config
 
         self._base_delay = 3

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -6,6 +6,7 @@ ZkClient module. Low-level KazooClient wrapper for ZooKeeper connection manageme
 import logging
 import os
 import time
+from configparser import RawConfigParser
 from dataclasses import dataclass
 from enum import Enum
 from random import uniform
@@ -109,52 +110,6 @@ class ZkClientConfig:
     verify_certs: bool = True
 
 
-def create_zk_client(config, state_listener=None, path_prefix=None):
-    """Factory: create ZkClient from config object."""
-    zk_auth = config.getboolean('global', 'zk_auth')
-    zk_ssl = config.getboolean('global', 'zk_ssl')
-
-    zk_username = None
-    zk_password = None
-    if zk_auth:
-        zk_username = config.get('global', 'zk_username')
-        zk_password = config.get('global', 'zk_password')
-        if not zk_username or not zk_password:
-            logging.error('zk_username, zk_password required when zk_auth enabled')
-
-    cert = None
-    key = None
-    ca = None
-    if zk_ssl:
-        cert = config.get('global', 'certfile')
-        key = config.get('global', 'keyfile')
-        ca = config.get('global', 'ca_cert')
-        if not cert or not key or not ca:
-            logging.error('certfile, keyfile, ca_cert required when zk_ssl enabled')
-
-    if path_prefix is None:
-        from . import helpers
-        path_prefix = helpers.get_lockpath_prefix()
-
-    zk_config = ZkClientConfig(
-        hosts=config.get('global', 'zk_hosts'),
-        timeout=config.getfloat('global', 'iteration_timeout'),
-        connect_max_delay=config.getfloat('global', 'zk_connect_max_delay'),
-        max_delay_on_reinit=config.getint('global', 'max_delay_on_zk_reinit'),
-        path_prefix=path_prefix,
-        auth=zk_auth,
-        username=zk_username,
-        password=zk_password,
-        ssl=zk_ssl,
-        cert=cert,
-        key=key,
-        ca=ca,
-        verify_certs=config.getboolean('global', 'verify_certs'),
-    )
-
-    return ZkClient(config=zk_config, state_listener=state_listener)
-
-
 class ZkClient(object):
     """
     Low-level ZooKeeper client wrapper.
@@ -165,14 +120,14 @@ class ZkClient(object):
     instead of raw kazoo exceptions.
     """
 
-    def __init__(self, config: ZkClientConfig, state_listener: Optional[Callable] = None):
+    def __init__(self, config: ZkClientConfig):
         self.config = config
 
         self._base_delay = 3
         self._failed_inits_count = 0
         self._session_expired = False
 
-        self._state_listener: Optional[Callable] = state_listener
+        self._state_listener: Optional[Callable] = None
         # Assigned by _create_kazoo_client() before any data method is called.
         self._kazoo: Optional[KazooClient] = None
 
@@ -365,18 +320,6 @@ class ZkClient(object):
         except (KazooException, KazooTimeoutError) as e:
             raise ZkClientError(e)
 
-    def get_mtime(self, path) -> float | None:
-        """Return last_modified (epoch) or None. Raises ZkClientError."""
-        try:
-            _, stat = self._client.get(self._resolve_path(path))
-            if stat is None:
-                return None
-            return stat.last_modified
-        except NoNodeError:
-            return None
-        except (KazooException, KazooTimeoutError) as e:
-            raise ZkClientError(e)
-
     def lock_version(self, path) -> str | None:
         """Return min lock sequence or None. Encapsulates '__' split. Raises ZkClientError."""
         try:
@@ -461,3 +404,49 @@ class ZkClient(object):
 
     def make_read_lock(self, path, identifier) -> LockHandle:
         return LockHandle(self._client.ReadLock(path, identifier))
+
+
+def create_zk_client(config: RawConfigParser, path_prefix=None) -> ZkClient:
+    """Factory: create ZkClient from config object."""
+    zk_auth = config.getboolean('global', 'zk_auth')
+    zk_ssl = config.getboolean('global', 'zk_ssl')
+
+    zk_username = None
+    zk_password = None
+    if zk_auth:
+        zk_username = config.get('global', 'zk_username')
+        zk_password = config.get('global', 'zk_password')
+        if not zk_username or not zk_password:
+            logging.error('zk_username, zk_password required when zk_auth enabled')
+
+    cert = None
+    key = None
+    ca = None
+    if zk_ssl:
+        cert = config.get('global', 'certfile')
+        key = config.get('global', 'keyfile')
+        ca = config.get('global', 'ca_cert')
+        if not cert or not key or not ca:
+            logging.error('certfile, keyfile, ca_cert required when zk_ssl enabled')
+
+    if path_prefix is None:
+        from . import helpers
+        path_prefix = helpers.get_lockpath_prefix()
+
+    zk_config = ZkClientConfig(
+        hosts=config.get('global', 'zk_hosts'),
+        timeout=config.getfloat('global', 'iteration_timeout'),
+        connect_max_delay=config.getfloat('global', 'zk_connect_max_delay'),
+        max_delay_on_reinit=config.getint('global', 'max_delay_on_zk_reinit'),
+        path_prefix=path_prefix,
+        auth=zk_auth,
+        username=zk_username,
+        password=zk_password,
+        ssl=zk_ssl,
+        cert=cert,
+        key=key,
+        ca=ca,
+        verify_certs=config.getboolean('global', 'verify_certs'),
+    )
+
+    return ZkClient(config=zk_config)

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -6,6 +6,7 @@ ZkClient module. Low-level KazooClient wrapper for ZooKeeper connection manageme
 import logging
 import os
 import time
+from dataclasses import dataclass
 from enum import Enum
 from random import uniform
 from typing import Callable, List, Optional
@@ -91,15 +92,27 @@ class LockHandle:
             raise ZkClientError(e)
 
 
+@dataclass
+class ZkClientConfig:
+    hosts: str
+    timeout: float
+    connect_max_delay: float
+    max_delay_on_reinit: int
+    path_prefix: str
+    auth: bool = False
+    username: str | None = None
+    password: str | None = None
+    ssl: bool = False
+    cert: str | None = None
+    key: str | None = None
+    ca: str | None = None
+    verify_certs: bool = True
+
+
 def create_zk_client(config, state_listener=None, path_prefix=None):
     """Factory: create ZkClient from config object."""
-    zk_hosts = config.get('global', 'zk_hosts')
-    timeout = config.getfloat('global', 'iteration_timeout')
-    connect_max_delay = config.getfloat('global', 'zk_connect_max_delay')
-    max_delay_on_reinit = config.getint('global', 'max_delay_on_zk_reinit')
     zk_auth = config.getboolean('global', 'zk_auth')
     zk_ssl = config.getboolean('global', 'zk_ssl')
-    verify_certs = config.getboolean('global', 'verify_certs')
 
     zk_username = None
     zk_password = None
@@ -123,11 +136,12 @@ def create_zk_client(config, state_listener=None, path_prefix=None):
         from . import helpers
         path_prefix = helpers.get_lockpath_prefix()
 
-    return ZkClient(
-        hosts=zk_hosts,
-        timeout=timeout,
-        connect_max_delay=connect_max_delay,
-        max_delay_on_reinit=max_delay_on_reinit,
+    zk_config = ZkClientConfig(
+        hosts=config.get('global', 'zk_hosts'),
+        timeout=config.getfloat('global', 'iteration_timeout'),
+        connect_max_delay=config.getfloat('global', 'zk_connect_max_delay'),
+        max_delay_on_reinit=config.getint('global', 'max_delay_on_zk_reinit'),
+        path_prefix=path_prefix,
         auth=zk_auth,
         username=zk_username,
         password=zk_password,
@@ -135,10 +149,10 @@ def create_zk_client(config, state_listener=None, path_prefix=None):
         cert=cert,
         key=key,
         ca=ca,
-        verify_certs=verify_certs,
-        state_listener=state_listener,
-        path_prefix=path_prefix,
+        verify_certs=config.getboolean('global', 'verify_certs'),
     )
+
+    return ZkClient(config=zk_config, state_listener=state_listener)
 
 
 class ZkClient(object):
@@ -151,36 +165,19 @@ class ZkClient(object):
     instead of raw kazoo exceptions.
     """
 
-    def __init__(
-        self,
-        hosts,
-        timeout,
-        connect_max_delay,
-        max_delay_on_reinit,
-        auth=False,
-        username=None,
-        password=None,
-        ssl=False,
-        cert=None,
-        key=None,
-        ca=None,
-        verify_certs=True,
-        state_listener: Optional[Callable] = None,
-        path_prefix='/pgconsul/',
-    ):
-        self._hosts = hosts
-        self._timeout = timeout
-        self._connect_max_delay = connect_max_delay
-        self._max_delay_on_reinit = max_delay_on_reinit
-        self._auth = auth
-        self._username = username
-        self._password = password
-        self._ssl = ssl
-        self._cert = cert
-        self._key = key
-        self._ca = ca
-        self._verify_certs = verify_certs
-        self._path_prefix = path_prefix
+    def __init__(self, config: ZkClientConfig = None, state_listener: Optional[Callable] = None, **kwargs):
+        if config is None:
+            # Support flat kwargs for backwards compatibility
+            config = ZkClientConfig(
+                hosts=kwargs['hosts'],
+                timeout=kwargs['timeout'],
+                connect_max_delay=kwargs['connect_max_delay'],
+                max_delay_on_reinit=kwargs['max_delay_on_reinit'],
+                path_prefix=kwargs.get('path_prefix', ''),
+                auth=kwargs.get('auth', False),
+                ssl=kwargs.get('ssl', False),
+            )
+        self.config = config
 
         self._base_delay = 3
         self._failed_inits_count = 0
@@ -205,18 +202,18 @@ class ZkClient(object):
         logging.debug("Initializing ZooKeeper client")
         self._create_kazoo_client()
         event = self._client.start_async()
-        event.wait(self._timeout)
+        event.wait(self.config.timeout)
         self._client.add_listener(self._listener)
 
         if not self._client.connected:
             logging.warning(
                 "ZooKeeper client failed to connect within timeout (%ds). Hosts: %s",
-                self._timeout,
-                self._hosts,
+                self.config.timeout,
+                self.config.hosts,
             )
             return False
 
-        logging.info("Successfully connected to ZooKeeper: %s", self._hosts)
+        logging.info("Successfully connected to ZooKeeper: %s", self.config.hosts)
         return True
 
     def reconnect(self) -> bool:
@@ -281,7 +278,7 @@ class ZkClient(object):
             'delay': 0.5,
             'backoff': 1.5,
             'max_jitter': 0.9,
-            'max_delay': self._connect_max_delay,
+            'max_delay': self.config.connect_max_delay,
         }
         command_retry_options = {
             'max_tries': 0,
@@ -291,30 +288,30 @@ class ZkClient(object):
             'max_delay': 5,
         }
         args = {
-            'hosts': self._hosts,
+            'hosts': self.config.hosts,
             'handler': SequentialThreadingHandler(),
-            'timeout': self._timeout,
+            'timeout': self.config.timeout,
             'connection_retry': conn_retry_options,
             'command_retry': command_retry_options,
         }
-        if self._auth:
-            acl = make_digest_acl(self._username, self._password, all=True)
+        if self.config.auth:
+            acl = make_digest_acl(self.config.username, self.config.password, all=True)
             args.update(
                 {
                     'default_acl': [acl],
                     'auth_data': [
-                        ('digest', '{username}:{password}'.format(username=self._username, password=self._password)),
+                        ('digest', '{username}:{password}'.format(username=self.config.username, password=self.config.password)),
                     ],
                 }
             )
-        if self._ssl:
+        if self.config.ssl:
             args.update(
                 {
                     'use_ssl': True,
-                    'certfile': self._cert,
-                    'keyfile': self._key,
-                    'ca': self._ca,
-                    'verify_certs': self._verify_certs,
+                    'certfile': self.config.cert,
+                    'keyfile': self.config.key,
+                    'ca': self.config.ca,
+                    'verify_certs': self.config.verify_certs,
                 }
             )
         self._kazoo = KazooClient(**args)
@@ -336,14 +333,14 @@ class ZkClient(object):
 
     def _sleep_before_reconnect(self):
         """Exponential backoff with jitter."""
-        max_sleep = min(self._base_delay * 2 ** self._failed_inits_count, self._max_delay_on_reinit)
+        max_sleep = min(self._base_delay * 2 ** self._failed_inits_count, self.config.max_delay_on_reinit)
         sleep_time = uniform(0, max_sleep)
         logging.warning(
             "ZK reconnection attempt #%d. Sleeping %.2fs (max: %.2fs, configured max: %ds)",
             self._failed_inits_count,
             sleep_time,
             max_sleep,
-            self._max_delay_on_reinit,
+            self.config.max_delay_on_reinit,
         )
         time.sleep(sleep_time)
 
@@ -359,22 +356,49 @@ class ZkClient(object):
             self._session_expired = False
 
     def _resolve_path(self, path):
-        if not path.startswith(self._path_prefix):
-            return os.path.join(self._path_prefix, path)
+        if not path.startswith(self.config.path_prefix):
+            return os.path.join(self.config.path_prefix, path)
         return path
 
     # === Data operations ===
 
-    def get(self, path):
-        """Return (data, stat). Raises ZkNoNodeError, ZkSessionExpiredError, ZkClientError."""
+    def get(self, path) -> str | None:
+        """Return decoded str or None. Raises ZkNoNodeError, ZkSessionExpiredError, ZkClientError."""
         try:
-            return self._client.get(self._resolve_path(path))
+            data, _ = self._client.get(self._resolve_path(path))
+            if data is None:
+                return None
+            return data.decode('utf-8')
         except NoNodeError as e:
             raise ZkNoNodeError(e)
         except SessionExpiredError as e:
             raise ZkSessionExpiredError(e)
         except (KazooException, KazooTimeoutError) as e:
             raise ZkClientError(e)
+
+    def get_mtime(self, path) -> float | None:
+        """Return last_modified (epoch) or None. Raises ZkClientError."""
+        try:
+            _, stat = self._client.get(self._resolve_path(path))
+            if stat is None:
+                return None
+            return stat.last_modified
+        except NoNodeError:
+            return None
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+
+    def lock_version(self, path) -> str | None:
+        """Return min lock sequence or None. Encapsulates '__' split. Raises ZkClientError."""
+        try:
+            children = self._client.get_children(self._resolve_path(path))
+        except NoNodeError:
+            return None
+        except (KazooException, KazooTimeoutError) as e:
+            raise ZkClientError(e)
+        if not children:
+            return None
+        return min(child.split('__')[-1] for child in children)
 
     def write(self, path, data):
         """

--- a/src/zk_client.py
+++ b/src/zk_client.py
@@ -134,7 +134,8 @@ class ZkClient(object):
     @property
     def _client(self) -> KazooClient:
         """Live KazooClient; raises if accessed before init()."""
-        assert self._kazoo is not None, "Kazoo client is not initialized"
+        if self._kazoo is None:
+            raise RuntimeError("Kazoo client is not initialized")
         return self._kazoo
 
     def set_state_listener(self, listener: Callable) -> None:
@@ -333,9 +334,10 @@ class ZkClient(object):
         return min(child.split('__')[-1] for child in children)
 
     def write(self, path, data):
-        """
-        Atomic write: set → create → set on race.
+        """Atomic write: set → create → set on race.
         Returns True. Raises ZkSessionExpiredError, ZkClientError on failure.
+        Note: create uses makepath=True — writing to a child of a deleted host node
+        will silently resurrect the parent; verify host membership before writing.
         """
         full_path = self._resolve_path(path)
         encoded = data.encode()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -89,4 +89,4 @@ def zk():
         config.getfloat.return_value = 5.0
         config.getboolean.return_value = False
         config.get.return_value = '/pgconsul/'
-        return create_zk(config, plugins=MagicMock())
+        return create_zk(config)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,15 +64,17 @@ def zk_client():
     """Create a ZkClient instance with mocked KazooClient."""
     with patch('src.zk_client.KazooClient'), \
          patch('src.zk_client.SequentialThreadingHandler'):
-        from src.zk_client import ZkClient
-        return ZkClient(
+        from src.zk_client import ZkClient, ZkClientConfig
+        config = ZkClientConfig(
             hosts='localhost:2181',
             timeout=5.0,
             connect_max_delay=10.0,
             max_delay_on_reinit=30,
+            path_prefix='/pgconsul/',
             auth=False,
             ssl=False,
         )
+        return ZkClient(config)
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,3 +34,21 @@ if 'src' not in sys.modules:
     _src_pkg.__path__ = [str(_ROOT / 'src')]
     _src_pkg.__package__ = 'src'
     sys.modules['src'] = _src_pkg
+
+
+import pytest  # noqa: E402  (import after sys.path bootstrap)
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+@pytest.fixture
+def zk():
+    """Create a Zookeeper instance with mocked Kazoo client and lock-path prefix."""
+    with patch('src.zk.KazooClient'), \
+         patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+        from src.zk import Zookeeper
+        config = MagicMock()
+        config.getint.return_value = 10
+        config.getfloat.return_value = 5.0
+        config.getboolean.return_value = False
+        config.get.return_value = '/pgconsul/'
+        return Zookeeper(config, plugins=MagicMock())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,13 +21,32 @@ if str(_ROOT) not in sys.path:
 
 for _mod_name in (
     'psycopg2', 'psycopg2.extensions', 'psycopg2.sql',
-    'kazoo', 'kazoo.client', 'kazoo.exceptions',
-    'kazoo.handlers', 'kazoo.handlers.threading',
+    'kazoo', 'kazoo.client',
+    'kazoo.handlers',
     'kazoo.recipe', 'kazoo.recipe.lock', 'kazoo.security',
     'lockfile', 'lockfile.pidlockfile', 'daemon',
 ):
     if _mod_name not in sys.modules:
         sys.modules[_mod_name] = MagicMock()
+
+# Stub kazoo.exceptions with real exception classes so that
+# `except KazooException` / `except NoNodeError` etc. work in unit tests.
+if 'kazoo.exceptions' not in sys.modules:
+    _kazoo_exc = types.ModuleType('kazoo.exceptions')
+    _kazoo_exc.KazooException = type('KazooException', (Exception,), {})
+    _kazoo_exc.NoNodeError = type('NoNodeError', (_kazoo_exc.KazooException,), {})
+    _kazoo_exc.NodeExistsError = type('NodeExistsError', (_kazoo_exc.KazooException,), {})
+    _kazoo_exc.SessionExpiredError = type('SessionExpiredError', (_kazoo_exc.KazooException,), {})
+    _kazoo_exc.ConnectionClosedError = type('ConnectionClosedError', (_kazoo_exc.KazooException,), {})
+    _kazoo_exc.LockTimeout = type('LockTimeout', (_kazoo_exc.KazooException,), {})
+    sys.modules['kazoo.exceptions'] = _kazoo_exc
+
+# Stub kazoo.handlers.threading with a real KazooTimeoutError class.
+if 'kazoo.handlers.threading' not in sys.modules:
+    _kazoo_threading = types.ModuleType('kazoo.handlers.threading')
+    _kazoo_threading.KazooTimeoutError = type('KazooTimeoutError', (Exception,), {})
+    _kazoo_threading.SequentialThreadingHandler = MagicMock()
+    sys.modules['kazoo.handlers.threading'] = _kazoo_threading
 
 if 'src' not in sys.modules:
     _src_pkg = types.ModuleType('src')
@@ -41,14 +60,31 @@ from unittest.mock import MagicMock, patch  # noqa: E402
 
 
 @pytest.fixture
+def zk_client():
+    """Create a ZkClient instance with mocked KazooClient."""
+    with patch('src.zk_client.KazooClient'), \
+         patch('src.zk_client.SequentialThreadingHandler'):
+        from src.zk_client import ZkClient
+        return ZkClient(
+            hosts='localhost:2181',
+            timeout=5.0,
+            connect_max_delay=10.0,
+            max_delay_on_reinit=30,
+            auth=False,
+            ssl=False,
+        )
+
+
+@pytest.fixture
 def zk():
     """Create a Zookeeper instance with mocked Kazoo client and lock-path prefix."""
-    with patch('src.zk.KazooClient'), \
+    with patch('src.zk_client.KazooClient'), \
+         patch('src.zk_client.SequentialThreadingHandler'), \
          patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-        from src.zk import Zookeeper
+        from src.zk import create_zk
         config = MagicMock()
         config.getint.return_value = 10
         config.getfloat.return_value = 5.0
         config.getboolean.return_value = False
         config.get.return_value = '/pgconsul/'
-        return Zookeeper(config, plugins=MagicMock())
+        return create_zk(config, plugins=MagicMock())

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -4,7 +4,7 @@ Unit tests for src/zk_client.py — low-level KazooClient wrapper.
 
 Covers: domain exceptions, LockHandle, ZkClientConfig, create_zk_client factory,
 ZkClient lifecycle (init, reconnect, is_alive, is_connected, close, listener),
-data operations (get, get_mtime, lock_version, write, ensure_path, exists,
+data operations (get, lock_version, write, ensure_path, exists,
 get_children, delete) and lock recipes (make_lock, make_read_lock).
 """
 
@@ -310,13 +310,6 @@ class TestCreateZkClient:
         passed_cfg = zk_cls.call_args.kwargs['config']
         assert passed_cfg.path_prefix == '/custom'
 
-    def test_state_listener_passed_through(self):
-        config = self._base_config()
-        listener = MagicMock()
-        with patch('src.zk_client.ZkClient') as zk_cls:
-            create_zk_client(config, state_listener=listener)
-        assert zk_cls.call_args.kwargs['state_listener'] is listener
-
 
 # === ZkClient lifecycle ===
 
@@ -557,31 +550,6 @@ class TestGet:
         client._kazoo.get.side_effect = KazooTimeoutError('timeout')
         with pytest.raises(ZkClientError):
             client.get('master')
-
-
-# === Data operations: get_mtime ===
-
-class TestGetMtime:
-    """get_mtime() returns last_modified or None."""
-
-    def test_get_mtime_returns_value(self, client):
-        client._kazoo.get.return_value = (b'data', _make_stat(999.0))
-        assert client.get_mtime('master') == 999.0
-
-    def test_get_mtime_returns_none_for_none_stat(self, client):
-        client._kazoo.get.return_value = (b'data', None)
-        assert client.get_mtime('master') is None
-
-    def test_get_mtime_no_node_returns_none(self, client):
-        from kazoo.exceptions import NoNodeError
-        client._kazoo.get.side_effect = NoNodeError('missing')
-        assert client.get_mtime('master') is None
-
-    def test_get_mtime_kazoo_exception(self, client):
-        from kazoo.exceptions import KazooException
-        client._kazoo.get.side_effect = KazooException('boom')
-        with pytest.raises(ZkClientError):
-            client.get_mtime('master')
 
 
 # === Data operations: lock_version ===

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -338,7 +338,7 @@ class TestZkClientInit:
         with patch('src.zk_client.KazooClient'), \
              patch('src.zk_client.SequentialThreadingHandler'):
             c = ZkClient(config=cfg)
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             _ = c._client
 
 

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -1,512 +1,830 @@
 # encoding: utf-8
-"""Unit tests for ZkClient class."""
+"""
+Unit tests for src/zk_client.py — low-level KazooClient wrapper.
 
-import pytest
+Covers: domain exceptions, LockHandle, ZkClientConfig, create_zk_client factory,
+ZkClient lifecycle (init, reconnect, is_alive, is_connected, close, listener),
+data operations (get, get_mtime, lock_version, write, ensure_path, exists,
+get_children, delete) and lock recipes (make_lock, make_read_lock).
+"""
+
 from unittest.mock import MagicMock, patch
 
-from kazoo.client import KazooState
+import pytest
 
 from src.zk_client import (
+    LockHandle,
+    ZkClient,
+    ZkClientConfig,
     ZkClientError,
     ZkConnectionClosedError,
-    ZkConnectionState,
     ZkLockTimeout,
     ZkNoNodeError,
     ZkSessionExpiredError,
+    create_zk_client,
 )
 
-# Real exception classes for tests that exercise except-clauses
-# (conftest stubs kazoo as MagicMock, so we define our own).
-_NoNodeError = type('NoNodeError', (Exception,), {})
-_NodeExistsError = type('NodeExistsError', (Exception,), {})
-_KazooException = type('KazooException', (Exception,), {})
-_SessionExpiredError = type('SessionExpiredError', (Exception,), {})
-_LockTimeout = type('LockTimeout', (Exception,), {})
-_ConnectionClosedError = type('ConnectionClosedError', (Exception,), {})
 
+# === Fixtures ===
 
-def create_mock_zk_client():
-    """ZkClient with mocked _kazoo for testing."""
-    from src.zk_client import ZkClient
-    client = ZkClient(
+@pytest.fixture
+def cfg():
+    return ZkClientConfig(
         hosts='localhost:2181',
         timeout=5.0,
         connect_max_delay=10.0,
         max_delay_on_reinit=30,
-        auth=False,
-        ssl=False,
+        path_prefix='/pgconsul',
     )
-    client._kazoo = MagicMock()
-    client._kazoo.connected = True
-    client._kazoo.state = KazooState.CONNECTED
-    return client
 
+
+@pytest.fixture
+def cfg_auth():
+    return ZkClientConfig(
+        hosts='localhost:2181',
+        timeout=5.0,
+        connect_max_delay=10.0,
+        max_delay_on_reinit=30,
+        path_prefix='/pgconsul',
+        auth=True,
+        username='user',
+        password='pass',
+    )
+
+
+@pytest.fixture
+def cfg_ssl():
+    return ZkClientConfig(
+        hosts='localhost:2181',
+        timeout=5.0,
+        connect_max_delay=10.0,
+        max_delay_on_reinit=30,
+        path_prefix='/pgconsul',
+        ssl=True,
+        cert='/cert.pem',
+        key='/key.pem',
+        ca='/ca.pem',
+        verify_certs=True,
+    )
+
+
+@pytest.fixture
+def client(cfg):
+    """ZkClient with mocked KazooClient (not started).
+
+    _create_kazoo_client is stubbed so that init()/reconnect() do not replace
+    the injected mock with a fresh MagicMock from the KazooClient constructor.
+    """
+    with patch('src.zk_client.KazooClient') as kc_cls, \
+         patch('src.zk_client.SequentialThreadingHandler'):
+        c = ZkClient(config=cfg)
+        kazoo = MagicMock()
+        kc_cls.return_value = kazoo
+        # Stub _create_kazoo_client to assign the same mock instance every time.
+        c._create_kazoo_client = lambda: setattr(c, '_kazoo', kazoo)
+        c._kazoo = kazoo
+        return c
+
+
+def _make_stat(last_modified=12345.0):
+    stat = MagicMock()
+    stat.last_modified = last_modified
+    return stat
+
+
+# === Domain exceptions ===
+
+class TestDomainExceptions:
+    """Domain exceptions form the expected hierarchy."""
+
+    def test_all_inherit_from_zkclient_error(self):
+        for exc in (ZkSessionExpiredError, ZkNoNodeError, ZkConnectionClosedError, ZkLockTimeout):
+            assert issubclass(exc, ZkClientError)
+
+    def test_zkclient_error_inherits_from_exception(self):
+        assert issubclass(ZkClientError, Exception)
+
+
+# === LockHandle ===
+
+class TestLockHandle:
+    """LockHandle translates kazoo exceptions to domain types."""
+
+    def test_acquire_success(self):
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        handle = LockHandle(lock)
+        assert handle.acquire(blocking=True, timeout=1) is True
+        lock.acquire.assert_called_once_with(blocking=True, timeout=1)
+
+    def test_acquire_lock_timeout(self):
+        from kazoo.exceptions import LockTimeout
+        lock = MagicMock()
+        lock.acquire.side_effect = LockTimeout('timeout')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkLockTimeout):
+            handle.acquire()
+
+    def test_acquire_kazoo_exception(self):
+        from kazoo.exceptions import KazooException
+        lock = MagicMock()
+        lock.acquire.side_effect = KazooException('boom')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkClientError):
+            handle.acquire()
+
+    def test_acquire_kazoo_timeout_error(self):
+        from kazoo.handlers.threading import KazooTimeoutError
+        lock = MagicMock()
+        lock.acquire.side_effect = KazooTimeoutError('timeout')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkClientError):
+            handle.acquire()
+
+    def test_release_success(self):
+        lock = MagicMock()
+        handle = LockHandle(lock)
+        handle.release()
+        lock.release.assert_called_once()
+
+    def test_release_connection_closed(self):
+        from kazoo.exceptions import ConnectionClosedError
+        lock = MagicMock()
+        lock.release.side_effect = ConnectionClosedError('closed')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkConnectionClosedError):
+            handle.release()
+
+    def test_release_kazoo_exception(self):
+        from kazoo.exceptions import KazooException
+        lock = MagicMock()
+        lock.release.side_effect = KazooException('boom')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkClientError):
+            handle.release()
+
+    def test_contenders_success(self):
+        lock = MagicMock()
+        lock.contenders.return_value = ['a', 'b']
+        handle = LockHandle(lock)
+        assert handle.contenders() == ['a', 'b']
+
+    def test_contenders_kazoo_exception(self):
+        from kazoo.exceptions import KazooException
+        lock = MagicMock()
+        lock.contenders.side_effect = KazooException('boom')
+        handle = LockHandle(lock)
+        with pytest.raises(ZkClientError):
+            handle.contenders()
+
+
+# === ZkClientConfig / create_zk_client factory ===
+
+class TestCreateZkClient:
+    """create_zk_client builds ZkClientConfig from a configparser-like object."""
+
+    def _base_config(self):
+        config = MagicMock()
+        config.getboolean.side_effect = lambda section, key: False
+        config.getfloat.return_value = 5.0
+        config.getint.return_value = 30
+        config.get.return_value = 'localhost:2181'
+        return config
+
+    def test_basic_config(self):
+        config = self._base_config()
+        with patch('src.zk_client.ZkClient') as zk_cls, \
+             patch('src.helpers.get_lockpath_prefix', return_value='/pgconsul'):
+            create_zk_client(config)
+        zk_cls.assert_called_once()
+        kw = zk_cls.call_args
+        passed_cfg = kw.kwargs['config']
+        assert passed_cfg.hosts == 'localhost:2181'
+        assert passed_cfg.timeout == 5.0
+        assert passed_cfg.connect_max_delay == 5.0
+        assert passed_cfg.max_delay_on_reinit == 30
+        assert passed_cfg.path_prefix == '/pgconsul'
+        assert passed_cfg.auth is False
+        assert passed_cfg.ssl is False
+
+    def test_auth_config(self):
+        config = self._base_config()
+
+        def getboolean(section, key):
+            if key == 'zk_auth':
+                return True
+            if key == 'zk_ssl':
+                return False
+            if key == 'verify_certs':
+                return True
+            return False
+
+        config.getboolean.side_effect = getboolean
+
+        def get(section, key):
+            if key == 'zk_username':
+                return 'user'
+            if key == 'zk_password':
+                return 'pass'
+            return 'localhost:2181'
+
+        config.get.side_effect = get
+
+        with patch('src.zk_client.ZkClient') as zk_cls, \
+             patch('src.helpers.get_lockpath_prefix', return_value='/pgconsul'):
+            create_zk_client(config)
+        passed_cfg = zk_cls.call_args.kwargs['config']
+        assert passed_cfg.auth is True
+        assert passed_cfg.username == 'user'
+        assert passed_cfg.password == 'pass'
+
+    def test_auth_missing_credentials_logs_error(self, caplog):
+        config = self._base_config()
+
+        def getboolean(section, key):
+            if key == 'zk_auth':
+                return True
+            return False
+
+        config.getboolean.side_effect = getboolean
+        config.get.return_value = ''  # empty username/password
+
+        with patch('src.zk_client.ZkClient'), \
+             patch('src.helpers.get_lockpath_prefix', return_value='/pgconsul'):
+            create_zk_client(config)
+        assert any('zk_username, zk_password required' in r.message for r in caplog.records)
+
+    def test_ssl_config(self):
+        config = self._base_config()
+
+        def getboolean(section, key):
+            if key == 'zk_ssl':
+                return True
+            if key == 'verify_certs':
+                return True
+            return False
+
+        config.getboolean.side_effect = getboolean
+
+        def get(section, key):
+            if key == 'certfile':
+                return '/cert.pem'
+            if key == 'keyfile':
+                return '/key.pem'
+            if key == 'ca_cert':
+                return '/ca.pem'
+            return 'localhost:2181'
+
+        config.get.side_effect = get
+
+        with patch('src.zk_client.ZkClient') as zk_cls, \
+             patch('src.helpers.get_lockpath_prefix', return_value='/pgconsul'):
+            create_zk_client(config)
+        passed_cfg = zk_cls.call_args.kwargs['config']
+        assert passed_cfg.ssl is True
+        assert passed_cfg.cert == '/cert.pem'
+        assert passed_cfg.key == '/key.pem'
+        assert passed_cfg.ca == '/ca.pem'
+        assert passed_cfg.verify_certs is True
+
+    def test_ssl_missing_certs_logs_error(self, caplog):
+        config = self._base_config()
+
+        def getboolean(section, key):
+            if key == 'zk_ssl':
+                return True
+            return False
+
+        config.getboolean.side_effect = getboolean
+        config.get.return_value = ''
+
+        with patch('src.zk_client.ZkClient'), \
+             patch('src.helpers.get_lockpath_prefix', return_value='/pgconsul'):
+            create_zk_client(config)
+        assert any('certfile, keyfile, ca_cert required' in r.message for r in caplog.records)
+
+    def test_explicit_path_prefix(self):
+        config = self._base_config()
+        with patch('src.zk_client.ZkClient') as zk_cls:
+            create_zk_client(config, path_prefix='/custom')
+        passed_cfg = zk_cls.call_args.kwargs['config']
+        assert passed_cfg.path_prefix == '/custom'
+
+    def test_state_listener_passed_through(self):
+        config = self._base_config()
+        listener = MagicMock()
+        with patch('src.zk_client.ZkClient') as zk_cls:
+            create_zk_client(config, state_listener=listener)
+        assert zk_cls.call_args.kwargs['state_listener'] is listener
+
+
+# === ZkClient lifecycle ===
 
 class TestZkClientInit:
+    """init() starts Kazoo and registers listener."""
 
-    def test_init_success(self):
-        from src.zk_client import ZkClient
-        mock_kazoo = MagicMock()
-        mock_kazoo.connected = True
-        mock_kazoo.start_async.return_value.wait.return_value = None
+    def test_init_success(self, client):
+        event = MagicMock()
+        event.wait.return_value = None
+        client._kazoo.start_async.return_value = event
+        client._kazoo.connected = True
 
-        with patch('src.zk_client.KazooClient', return_value=mock_kazoo), \
+        assert client.init() is True
+        client._kazoo.start_async.assert_called_once()
+        event.wait.assert_called_once_with(client.config.timeout)
+        client._kazoo.add_listener.assert_called_once_with(client._listener)
+
+    def test_init_failure_not_connected(self, client):
+        event = MagicMock()
+        client._kazoo.start_async.return_value = event
+        client._kazoo.connected = False
+
+        assert client.init() is False
+
+    def test_client_property_raises_before_init(self, cfg):
+        with patch('src.zk_client.KazooClient'), \
              patch('src.zk_client.SequentialThreadingHandler'):
-            client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
-            result = client.init()
-
-        assert result is True
-        mock_kazoo.start_async.assert_called_once()
-        mock_kazoo.add_listener.assert_called_once()
-
-    def test_init_failure_returns_false(self):
-        from src.zk_client import ZkClient
-        mock_kazoo = MagicMock()
-        mock_kazoo.connected = False
-
-        with patch('src.zk_client.KazooClient', return_value=mock_kazoo), \
-             patch('src.zk_client.SequentialThreadingHandler'):
-            client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
-            result = client.init()
-
-        assert result is False
-
-
-class TestZkClientIsAlive:
-
-    def test_is_alive_connected(self):
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.CONNECTED
-        client._session_expired = False
-        assert client.is_alive() is True
-
-    def test_is_alive_session_expired(self):
-        """Session expired → False even if Kazoo reports CONNECTED."""
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.CONNECTED
-        client._session_expired = True
-        assert client.is_alive() is False
-
-    def test_is_alive_suspended(self):
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.SUSPENDED
-        assert client.is_alive() is False
-
-    def test_is_alive_pure_no_side_effects(self):
-        """is_alive() must not modify flags (pure query)."""
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.CONNECTED
-        client._session_expired = True
-        client._failed_inits_count = 3
-
-        client.is_alive()
-
-        # Flags must not be cleared by is_alive — listener/reconnect owns that.
-        assert client._session_expired is True
-        assert client._failed_inits_count == 3
-
-
-class TestZkClientIsConnected:
-
-    def test_is_connected_when_connected(self):
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.CONNECTED
-        assert client.is_connected() is True
-
-    def test_is_connected_when_suspended(self):
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.SUSPENDED
-        assert client.is_connected() is False
-
-    def test_is_connected_no_side_effects(self):
-        """is_connected() must not modify state flags."""
-        client = create_mock_zk_client()
-        client._kazoo.state = KazooState.CONNECTED
-        client._session_expired = True
-        client._failed_inits_count = 5
-
-        client.is_connected()
-
-        assert client._session_expired is True
-        assert client._failed_inits_count == 5
-
-
-class TestZkClientSetStateListener:
-
-    def test_set_state_listener_replaces_existing(self):
-        client = create_mock_zk_client()
-        first = MagicMock()
-        second = MagicMock()
-        client.set_state_listener(first)
-        client.set_state_listener(second)
-        client._listener(KazooState.CONNECTED)
-        first.assert_not_called()
-        second.assert_called_once_with(ZkConnectionState.CONNECTED)
+            c = ZkClient(config=cfg)
+        with pytest.raises(AssertionError):
+            _ = c._client
 
 
 class TestZkClientReconnect:
+    """reconnect() rebuilds connection with backoff."""
 
-    def test_reconnect_success(self):
-        client = create_mock_zk_client()
-        client._failed_inits_count = 3
-        client._session_expired = True
+    def test_reconnect_success(self, client):
+        client._kazoo.connected = True
+        event = MagicMock()
+        client._kazoo.start_async.return_value = event
+        client._kazoo.state = MagicMock()  # will be compared via ==
+        # Make is_connected return True: state == KazooState.CONNECTED
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
 
-        new_kazoo = MagicMock()
-        new_kazoo.connected = True
-        new_kazoo.state = KazooState.CONNECTED
-
-        with patch.object(client, '_sleep_before_reconnect'), \
-             patch('src.zk_client.KazooClient', return_value=new_kazoo), \
-             patch('src.zk_client.SequentialThreadingHandler'):
-            result = client.reconnect()
-
-        assert result is True
+        assert client.reconnect() is True
+        client._kazoo.remove_listener.assert_called_once_with(client._listener)
+        client._kazoo.stop.assert_called_once()
+        client._kazoo.close.assert_called_once()
         assert client._session_expired is False
+        assert client._failed_inits_count == 0
 
-    def test_reconnect_failure_increments_counter(self):
-        client = create_mock_zk_client()
+    def test_reconnect_failure_increments_counter(self, client):
+        event = MagicMock()
+        client._kazoo.start_async.return_value = event
         client._kazoo.connected = False
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.LOST
 
-        with patch.object(client, '_sleep_before_reconnect'):
-            result = client.reconnect()
+        assert client.reconnect() is False
+        assert client._session_expired is True
+        assert client._failed_inits_count == 1
 
-        assert result is False
+    def test_reconnect_sleeps_when_failed_before(self, client):
+        client._failed_inits_count = 2
+        event = MagicMock()
+        client._kazoo.start_async.return_value = event
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
+
+        with patch('src.zk_client.time.sleep') as sleep_mock, \
+             patch('src.zk_client.uniform', return_value=1.0):
+            client.reconnect()
+        sleep_mock.assert_called_once()
+
+    def test_reconnect_no_sleep_on_first_attempt(self, client):
+        """First reconnect (failed_inits_count == 0) must not sleep."""
+        event = MagicMock()
+        client._kazoo.start_async.return_value = event
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
+
+        with patch('src.zk_client.time.sleep') as sleep_mock:
+            client.reconnect()
+        sleep_mock.assert_not_called()
+
+    def test_reconnect_exception_returns_false(self, client):
+        client._kazoo.remove_listener.side_effect = Exception('boom')
+
+        assert client.reconnect() is False
         assert client._session_expired is True
         assert client._failed_inits_count == 1
 
 
-class TestZkClientClose:
+class TestZkClientState:
+    """is_alive / is_connected pure state checks."""
 
-    def test_close_removes_listener_and_stops(self):
-        client = create_mock_zk_client()
+    def test_is_alive_true(self, client):
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = False
+        assert client.is_alive() is True
+
+    def test_is_alive_false_when_session_expired(self, client):
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = True
+        assert client.is_alive() is False
+
+    def test_is_alive_false_when_not_connected(self, client):
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.SUSPENDED
+        assert client.is_alive() is False
+
+    def test_is_connected_true(self, client):
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.CONNECTED
+        assert client.is_connected() is True
+
+    def test_is_connected_false(self, client):
+        from kazoo.client import KazooState
+        client._kazoo.state = KazooState.LOST
+        assert client.is_connected() is False
+
+
+class TestZkClientClose:
+    """close() removes listener, stops and closes Kazoo."""
+
+    def test_close_full(self, client):
         client.close()
-        client._kazoo.remove_listener.assert_called_once()
+        client._kazoo.remove_listener.assert_called_once_with(client._listener)
         client._kazoo.stop.assert_called_once()
         client._kazoo.close.assert_called_once()
 
-    def test_close_handles_none_kazoo(self):
-        from src.zk_client import ZkClient
-        client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
-        client.close()  # should not raise
+    def test_close_when_not_initialized(self, cfg):
+        with patch('src.zk_client.KazooClient'), \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            c = ZkClient(config=cfg)
+        # Should not raise.
+        c.close()
+
+    def test_close_swallows_exceptions(self, client):
+        client._kazoo.remove_listener.side_effect = Exception('boom')
+        client._kazoo.stop.side_effect = Exception('boom')
+        # Should not raise.
+        client.close()
 
 
-class TestZkClientListener:
+# === Listener ===
 
-    def test_listener_lost_sets_session_expired(self):
-        client = create_mock_zk_client()
-        client._session_expired = False
+class TestListener:
+    """_listener updates session flags and notifies external listener."""
+
+    def test_listener_lost_sets_session_expired(self, client):
+        from kazoo.client import KazooState
+        listener = MagicMock()
+        client._state_listener = listener
         client._listener(KazooState.LOST)
         assert client._session_expired is True
+        listener.assert_called_once()
 
-    def test_listener_connected_clears_flags(self):
-        client = create_mock_zk_client()
+    def test_listener_connected_clears_flags(self, client):
+        from kazoo.client import KazooState
         client._session_expired = True
-        client._failed_inits_count = 5
+        client._failed_inits_count = 3
+        listener = MagicMock()
+        client._state_listener = listener
         client._listener(KazooState.CONNECTED)
         assert client._session_expired is False
         assert client._failed_inits_count == 0
+        listener.assert_called_once()
 
-    def test_listener_calls_external_callback_with_domain_state(self):
-        """External callback receives ZkConnectionState, not KazooState."""
-        client = create_mock_zk_client()
-        callback = MagicMock()
-        client._state_listener = callback
-        client._listener(KazooState.CONNECTED)
-        callback.assert_called_once_with(ZkConnectionState.CONNECTED)
-
-    def test_listener_maps_lost_to_domain_state(self):
-        client = create_mock_zk_client()
-        callback = MagicMock()
-        client._state_listener = callback
-        client._listener(KazooState.LOST)
-        callback.assert_called_once_with(ZkConnectionState.LOST)
-
-    def test_listener_maps_suspended_to_domain_state(self):
-        client = create_mock_zk_client()
-        callback = MagicMock()
-        client._state_listener = callback
+    def test_listener_suspended_no_flag_change(self, client):
+        from kazoo.client import KazooState
+        listener = MagicMock()
+        client._state_listener = listener
         client._listener(KazooState.SUSPENDED)
-        callback.assert_called_once_with(ZkConnectionState.SUSPENDED)
+        # session_expired unchanged (False by default)
+        listener.assert_called_once()
 
-    def test_listener_no_error_when_callback_is_none(self):
-        client = create_mock_zk_client()
+    def test_listener_without_external_listener(self, client):
+        from kazoo.client import KazooState
         client._state_listener = None
-        client._listener(KazooState.CONNECTED)  # must not raise
+        # Should not raise.
+        client._listener(KazooState.LOST)
+
+    def test_set_state_listener(self, client):
+        listener = MagicMock()
+        client.set_state_listener(listener)
+        assert client._state_listener is listener
 
 
-class TestZkClientStateFlags:
+# === _resolve_path ===
 
-    def test_clear_connection_state_flags(self):
-        client = create_mock_zk_client()
+class TestResolvePath:
+    """_resolve_path prepends path_prefix when missing."""
+
+    def test_prepends_prefix(self, client):
+        assert client._resolve_path('master') == '/pgconsul/master'
+
+    def test_no_double_prefix(self, client):
+        assert client._resolve_path('/pgconsul/master') == '/pgconsul/master'
+
+
+# === Data operations: get ===
+
+class TestGet:
+    """get() returns decoded str, None, or raises domain exceptions."""
+
+    def test_get_returns_decoded_str(self, client):
+        client._kazoo.get.return_value = (b'hello', _make_stat())
+        assert client.get('master') == 'hello'
+        client._kazoo.get.assert_called_once_with('/pgconsul/master')
+
+    def test_get_returns_none_for_none_data(self, client):
+        client._kazoo.get.return_value = (None, _make_stat())
+        assert client.get('master') is None
+
+    def test_get_no_node_error(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.get.side_effect = NoNodeError('missing')
+        with pytest.raises(ZkNoNodeError):
+            client.get('master')
+
+    def test_get_session_expired(self, client):
+        from kazoo.exceptions import SessionExpiredError
+        client._kazoo.get.side_effect = SessionExpiredError('expired')
+        with pytest.raises(ZkSessionExpiredError):
+            client.get('master')
+
+    def test_get_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.get.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.get('master')
+
+    def test_get_kazoo_timeout(self, client):
+        from kazoo.handlers.threading import KazooTimeoutError
+        client._kazoo.get.side_effect = KazooTimeoutError('timeout')
+        with pytest.raises(ZkClientError):
+            client.get('master')
+
+
+# === Data operations: get_mtime ===
+
+class TestGetMtime:
+    """get_mtime() returns last_modified or None."""
+
+    def test_get_mtime_returns_value(self, client):
+        client._kazoo.get.return_value = (b'data', _make_stat(999.0))
+        assert client.get_mtime('master') == 999.0
+
+    def test_get_mtime_returns_none_for_none_stat(self, client):
+        client._kazoo.get.return_value = (b'data', None)
+        assert client.get_mtime('master') is None
+
+    def test_get_mtime_no_node_returns_none(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.get.side_effect = NoNodeError('missing')
+        assert client.get_mtime('master') is None
+
+    def test_get_mtime_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.get.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.get_mtime('master')
+
+
+# === Data operations: lock_version ===
+
+class TestLockVersion:
+    """lock_version() returns min lock sequence or None."""
+
+    def test_lock_version_returns_min(self, client):
+        client._kazoo.get_children.return_value = ['lock__001', 'lock__003', 'lock__002']
+        assert client.lock_version('master') == '001'
+
+    def test_lock_version_empty_children(self, client):
+        client._kazoo.get_children.return_value = []
+        assert client.lock_version('master') is None
+
+    def test_lock_version_no_node(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.get_children.side_effect = NoNodeError('missing')
+        assert client.lock_version('master') is None
+
+    def test_lock_version_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.get_children.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.lock_version('master')
+
+
+# === Data operations: write ===
+
+class TestWrite:
+    """write() atomic set → create → set on race."""
+
+    def test_write_set_existing(self, client):
+        client._kazoo.set.return_value = _make_stat()
+        assert client.write('master', 'value') is True
+        client._kazoo.set.assert_called_once_with('/pgconsul/master', b'value')
+
+    def test_write_create_when_no_node(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.set.side_effect = NoNodeError('missing')
+        client._kazoo.create.return_value = '/pgconsul/master'
+        assert client.write('master', 'value') is True
+        client._kazoo.create.assert_called_once_with('/pgconsul/master', value=b'value', makepath=True)
+
+    def test_write_create_then_node_exists_race(self, client):
+        from kazoo.exceptions import NoNodeError, NodeExistsError
+        client._kazoo.set.side_effect = NoNodeError('missing')
+        client._kazoo.create.side_effect = NodeExistsError('exists')
+        client._kazoo.set.return_value = _make_stat()
+        # First set raises NoNodeError, create raises NodeExistsError, second set succeeds.
+        # Need set to succeed on second call.
+        client._kazoo.set.side_effect = [NoNodeError('missing'), _make_stat()]
+        assert client.write('master', 'value') is True
+        assert client._kazoo.set.call_count == 2
+
+    def test_write_session_expired(self, client):
+        from kazoo.exceptions import SessionExpiredError
+        client._kazoo.set.side_effect = SessionExpiredError('expired')
+        with pytest.raises(ZkSessionExpiredError):
+            client.write('master', 'value')
+
+    def test_write_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.set.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.write('master', 'value')
+
+
+# === Data operations: ensure_path / exists / get_children / delete ===
+
+class TestEnsurePath:
+    def test_ensure_path_success(self, client):
+        client._kazoo.ensure_path.return_value = 'stat'
+        assert client.ensure_path('master') == 'stat'
+        client._kazoo.ensure_path.assert_called_once_with('/pgconsul/master')
+
+    def test_ensure_path_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.ensure_path.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.ensure_path('master')
+
+
+class TestExists:
+    def test_exists_true(self, client):
+        client._kazoo.exists.return_value = _make_stat()
+        assert client.exists('master') is True
+
+    def test_exists_false(self, client):
+        client._kazoo.exists.return_value = None
+        assert client.exists('master') is False
+
+    def test_exists_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.exists.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.exists('master')
+
+
+class TestGetChildren:
+    def test_get_children_returns_list(self, client):
+        client._kazoo.get_children.return_value = ['a', 'b']
+        assert client.get_children('master') == ['a', 'b']
+
+    def test_get_children_no_node_returns_empty(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.get_children.side_effect = NoNodeError('missing')
+        assert client.get_children('master') == []
+
+    def test_get_children_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.get_children.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.get_children('master')
+
+
+class TestDelete:
+    def test_delete_success(self, client):
+        assert client.delete('master') is True
+        client._kazoo.delete.assert_called_once_with('/pgconsul/master', recursive=False)
+
+    def test_delete_recursive(self, client):
+        client.delete('master', recursive=True)
+        client._kazoo.delete.assert_called_once_with('/pgconsul/master', recursive=True)
+
+    def test_delete_no_node_returns_true(self, client):
+        from kazoo.exceptions import NoNodeError
+        client._kazoo.delete.side_effect = NoNodeError('missing')
+        assert client.delete('master') is True
+
+    def test_delete_kazoo_exception(self, client):
+        from kazoo.exceptions import KazooException
+        client._kazoo.delete.side_effect = KazooException('boom')
+        with pytest.raises(ZkClientError):
+            client.delete('master')
+
+
+# === Lock recipes ===
+
+class TestLockRecipes:
+    """make_lock / make_read_lock wrap kazoo locks in LockHandle."""
+
+    def test_make_lock(self, client):
+        lock = MagicMock()
+        client._kazoo.Lock.return_value = lock
+        handle = client.make_lock('/pgconsul/master', 'host1')
+        assert isinstance(handle, LockHandle)
+        client._kazoo.Lock.assert_called_once_with('/pgconsul/master', 'host1')
+
+    def test_make_read_lock(self, client):
+        lock = MagicMock()
+        client._kazoo.ReadLock.return_value = lock
+        handle = client.make_read_lock('/pgconsul/master', 'host1')
+        assert isinstance(handle, LockHandle)
+        client._kazoo.ReadLock.assert_called_once_with('/pgconsul/master', 'host1')
+
+
+# === _create_kazoo_client ===
+
+class TestCreateKazooClient:
+    """_create_kazoo_client builds KazooClient with proper args."""
+
+    def test_basic(self, cfg):
+        with patch('src.zk_client.KazooClient') as kc_cls, \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            c = ZkClient(config=cfg)
+            c._create_kazoo_client()
+            kc_cls.assert_called_once()
+            args = kc_cls.call_args.kwargs
+            assert args['hosts'] == 'localhost:2181'
+            assert args['timeout'] == 5.0
+            assert 'connection_retry' in args
+            assert 'command_retry' in args
+            assert 'default_acl' not in args
+            assert 'use_ssl' not in args
+
+    def test_auth_adds_acl(self, cfg_auth):
+        with patch('src.zk_client.KazooClient') as kc_cls, \
+             patch('src.zk_client.SequentialThreadingHandler'), \
+             patch('src.zk_client.make_digest_acl') as acl_mock:
+            c = ZkClient(config=cfg_auth)
+            c._create_kazoo_client()
+            acl_mock.assert_called_once_with('user', 'pass', all=True)
+            args = kc_cls.call_args.kwargs
+            assert 'default_acl' in args
+            assert 'auth_data' in args
+            assert args['auth_data'] == [('digest', 'user:pass')]
+
+    def test_ssl_adds_ssl_args(self, cfg_ssl):
+        with patch('src.zk_client.KazooClient') as kc_cls, \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            c = ZkClient(config=cfg_ssl)
+            c._create_kazoo_client()
+            args = kc_cls.call_args.kwargs
+            assert args['use_ssl'] is True
+            assert args['certfile'] == '/cert.pem'
+            assert args['keyfile'] == '/key.pem'
+            assert args['ca'] == '/ca.pem'
+            assert args['verify_certs'] is True
+
+
+# === _sleep_before_reconnect / flag clearing ===
+
+class TestSleepAndFlags:
+    """Exponential backoff and flag clearing helpers."""
+
+    def test_sleep_before_reconnect(self, client):
+        client._failed_inits_count = 2
+        with patch('src.zk_client.time.sleep') as sleep_mock, \
+             patch('src.zk_client.uniform', return_value=2.5) as uniform_mock:
+            client._sleep_before_reconnect()
+        uniform_mock.assert_called_once()
+        sleep_mock.assert_called_once_with(2.5)
+
+    def test_sleep_capped_by_max_delay(self, client):
+        """max_sleep must not exceed config.max_delay_on_reinit."""
+        client._failed_inits_count = 100  # huge count
+        client.config.max_delay_on_reinit = 30
+        with patch('src.zk_client.time.sleep'), \
+             patch('src.zk_client.uniform') as uniform_mock:
+            client._sleep_before_reconnect()
+        # uniform(0, max_sleep) where max_sleep <= 30
+        max_sleep_arg = uniform_mock.call_args.args[1]
+        assert max_sleep_arg <= 30
+
+    def test_clear_connection_state_flags(self, client):
         client._session_expired = True
         client._failed_inits_count = 5
         client._clear_connection_state_flags()
         assert client._session_expired is False
         assert client._failed_inits_count == 0
 
-    def test_clear_session_expired_flag_only(self):
-        client = create_mock_zk_client()
+    def test_clear_connection_state_flags_no_reset_when_zero(self, client):
+        client._failed_inits_count = 0
+        client._clear_connection_state_flags()
+        assert client._failed_inits_count == 0
+
+    def test_clear_session_expired_flag(self, client):
         client._session_expired = True
-        client._failed_inits_count = 5
         client._clear_session_expired_flag()
         assert client._session_expired is False
-        assert client._failed_inits_count == 5
 
-
-class TestZkClientResolvePath:
-
-    def test_does_not_double_prefix(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        assert client._resolve_path('/pgconsul/leader') == '/pgconsul/leader'
-
-
-class TestZkClientDataOps:
-
-    def test_get_returns_none_for_empty_node(self):
-        client = create_mock_zk_client()
-        client._kazoo.get.return_value = (None, MagicMock())
-        assert client.get('leader') is None
-
-    def test_get_raises_zk_no_node_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.get.side_effect = _NoNodeError()
-            with pytest.raises(ZkNoNodeError):
-                client.get('missing')
-
-    def test_get_raises_zk_session_expired_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.SessionExpiredError', _SessionExpiredError):
-            client._kazoo.get.side_effect = _SessionExpiredError()
-            with pytest.raises(ZkSessionExpiredError):
-                client.get('leader')
-
-    def test_get_raises_zk_client_error_on_kazoo_exception(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.get.side_effect = _KazooException("conn error")
-            with pytest.raises(ZkClientError):
-                client.get('leader')
-
-    def test_write_retries_set_on_race(self):
-        """NodeExistsError during create → retry set."""
-        _NoNode = type('NoNodeError', (Exception,), {})
-        _NodeExists = type('NodeExistsError', (Exception,), {})
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        with patch('src.zk_client.NoNodeError', _NoNode), \
-             patch('src.zk_client.NodeExistsError', _NodeExists):
-            client._kazoo.set.side_effect = [_NoNode(), None]
-            client._kazoo.create.side_effect = _NodeExists()
-            client.write('leader', 'host1')
-        assert client._kazoo.set.call_count == 2
-
-    def test_write_raises_zk_session_expired(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.SessionExpiredError', _SessionExpiredError), \
-             patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.set.side_effect = _SessionExpiredError()
-            with pytest.raises(ZkSessionExpiredError):
-                client.write('leader', 'val')
-
-    def test_exists_returns_true_when_node_exists(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client._kazoo.exists.return_value = MagicMock()
-        assert client.exists('leader') is True
-
-    def test_exists_returns_false_when_absent(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client._kazoo.exists.return_value = None
-        assert client.exists('leader') is False
-
-    def test_exists_raises_zk_client_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.exists.side_effect = _KazooException("conn error")
-            with pytest.raises(ZkClientError):
-                client.exists('leader')
-
-    def test_get_children_returns_list(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client._kazoo.get_children.return_value = ['a', 'b']
-        assert client.get_children('all_hosts') == ['a', 'b']
-
-    def test_get_children_returns_empty_on_no_node(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.get_children.side_effect = _NoNodeError()
-            assert client.get_children('missing') == []
-
-    def test_get_children_raises_zk_client_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError), \
-             patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.get_children.side_effect = _KazooException("conn error")
-            with pytest.raises(ZkClientError):
-                client.get_children('leader')
-
-    def test_ensure_path_raises_zk_client_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.ensure_path.side_effect = _KazooException("conn error")
-            with pytest.raises(ZkClientError):
-                client.ensure_path('some/path')
-
-    def test_delete_returns_true_on_no_node(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.delete.side_effect = _NoNodeError()
-            assert client.delete('missing') is True
-
-    def test_delete_raises_zk_client_error_on_kazoo_exception(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError), \
-             patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.delete.side_effect = _KazooException("err")
-            with pytest.raises(ZkClientError):
-                client.delete('leader')
-
-
-class TestZkClientLockRecipes:
-
-    def test_make_lock_returns_lock_handle(self):
-        from src.zk_client import LockHandle
-        client = create_mock_zk_client()
-        mock_lock = MagicMock()
-        client._kazoo.Lock.return_value = mock_lock
-        result = client.make_lock('/pgconsul/leader', 'host1')
-        client._kazoo.Lock.assert_called_once_with('/pgconsul/leader', 'host1')
-        assert isinstance(result, LockHandle)
-
-    def test_make_read_lock_returns_lock_handle(self):
-        from src.zk_client import LockHandle
-        client = create_mock_zk_client()
-        mock_lock = MagicMock()
-        client._kazoo.ReadLock.return_value = mock_lock
-        result = client.make_read_lock('/pgconsul/leader', 'host1')
-        client._kazoo.ReadLock.assert_called_once_with('/pgconsul/leader', 'host1')
-        assert isinstance(result, LockHandle)
-
-
-class TestLockHandle:
-
-    def _make_handle(self):
-        from src.zk_client import LockHandle
-        mock_lock = MagicMock()
-        return LockHandle(mock_lock), mock_lock
-
-    def test_acquire_delegates(self):
-        handle, mock_lock = self._make_handle()
-        mock_lock.acquire.return_value = True
-        assert handle.acquire(blocking=True, timeout=5) is True
-        mock_lock.acquire.assert_called_once_with(blocking=True, timeout=5)
-
-    def test_acquire_translates_lock_timeout(self):
-        handle, mock_lock = self._make_handle()
-        with patch('src.zk_client.LockTimeout', _LockTimeout):
-            mock_lock.acquire.side_effect = _LockTimeout()
-            with pytest.raises(ZkLockTimeout):
-                handle.acquire()
-
-    def test_acquire_translates_kazoo_exception(self):
-        handle, mock_lock = self._make_handle()
-        with patch('src.zk_client.KazooException', _KazooException):
-            mock_lock.acquire.side_effect = _KazooException()
-            with pytest.raises(ZkClientError):
-                handle.acquire()
-
-    def test_release_delegates(self):
-        handle, mock_lock = self._make_handle()
-        handle.release()
-        mock_lock.release.assert_called_once()
-
-    def test_release_translates_connection_closed(self):
-        handle, mock_lock = self._make_handle()
-        with patch('src.zk_client.ConnectionClosedError', _ConnectionClosedError):
-            mock_lock.release.side_effect = _ConnectionClosedError()
-            with pytest.raises(ZkConnectionClosedError):
-                handle.release()
-
-    def test_release_translates_kazoo_exception(self):
-        handle, mock_lock = self._make_handle()
-        with patch('src.zk_client.KazooException', _KazooException):
-            mock_lock.release.side_effect = _KazooException()
-            with pytest.raises(ZkClientError):
-                handle.release()
-
-    def test_contenders_delegates(self):
-        handle, mock_lock = self._make_handle()
-        mock_lock.contenders.return_value = ['host1', 'host2']
-        assert handle.contenders() == ['host1', 'host2']
-
-    def test_contenders_translates_kazoo_exception(self):
-        handle, mock_lock = self._make_handle()
-        with patch('src.zk_client.KazooException', _KazooException):
-            mock_lock.contenders.side_effect = _KazooException()
-            with pytest.raises(ZkClientError):
-                handle.contenders()
-
-
-class TestZkClientGetMtime:
-
-    def test_get_mtime_returns_float(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        stat = MagicMock()
-        stat.last_modified = 1234567890.5
-        client._kazoo.get.return_value = (b'data', stat)
-        assert client.get_mtime('leader') == 1234567890.5
-
-    def test_get_mtime_returns_none_on_no_node(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.get.side_effect = _NoNodeError()
-            assert client.get_mtime('missing') is None
-
-    def test_get_mtime_returns_none_when_stat_is_none(self):
-        client = create_mock_zk_client()
-        client._kazoo.get.return_value = (b'data', None)
-        assert client.get_mtime('leader') is None
-
-    def test_get_mtime_raises_zk_client_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.get.side_effect = _KazooException("err")
-            with pytest.raises(ZkClientError):
-                client.get_mtime('leader')
-
-
-class TestZkClientLockVersion:
-
-    def test_lock_version_returns_min_sequence(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client._kazoo.get_children.return_value = ['host1__0000000003', 'host2__0000000001', 'host3__0000000002']
-        assert client.lock_version('/pgconsul/leader') == '0000000001'
-
-    def test_lock_version_returns_none_when_no_children(self):
-        client = create_mock_zk_client()
-        client._kazoo.get_children.return_value = []
-        assert client.lock_version('/pgconsul/leader') is None
-
-    def test_lock_version_returns_none_on_no_node(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.NoNodeError', _NoNodeError):
-            client._kazoo.get_children.side_effect = _NoNodeError()
-            assert client.lock_version('/pgconsul/leader') is None
-
-    def test_lock_version_raises_zk_client_error(self):
-        client = create_mock_zk_client()
-        with patch('src.zk_client.KazooException', _KazooException):
-            client._kazoo.get_children.side_effect = _KazooException("err")
-            with pytest.raises(ZkClientError):
-                client.lock_version('/pgconsul/leader')
-
-    def test_lock_version_single_child(self):
-        client = create_mock_zk_client()
-        client._kazoo.get_children.return_value = ['host1__0000000007']
-        assert client.lock_version('/pgconsul/leader') == '0000000007'
+    def test_clear_session_expired_flag_noop(self, client):
+        client._session_expired = False
+        client._clear_session_expired_flag()
+        assert client._session_expired is False

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -1,0 +1,481 @@
+# encoding: utf-8
+"""Unit tests for ZkClient class."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from kazoo.client import KazooState
+
+from src.zk_client import (
+    ZkClientError,
+    ZkConnectionClosedError,
+    ZkConnectionState,
+    ZkLockTimeout,
+    ZkNoNodeError,
+    ZkSessionExpiredError,
+)
+
+# Real exception classes for tests that exercise except-clauses
+# (conftest stubs kazoo as MagicMock, so we define our own).
+_NoNodeError = type('NoNodeError', (Exception,), {})
+_NodeExistsError = type('NodeExistsError', (Exception,), {})
+_KazooException = type('KazooException', (Exception,), {})
+_SessionExpiredError = type('SessionExpiredError', (Exception,), {})
+_LockTimeout = type('LockTimeout', (Exception,), {})
+_ConnectionClosedError = type('ConnectionClosedError', (Exception,), {})
+
+
+def create_mock_zk_client():
+    """ZkClient with mocked _kazoo for testing."""
+    from src.zk_client import ZkClient
+    client = ZkClient(
+        hosts='localhost:2181',
+        timeout=5.0,
+        connect_max_delay=10.0,
+        max_delay_on_reinit=30,
+        auth=False,
+        ssl=False,
+    )
+    client._kazoo = MagicMock()
+    client._kazoo.connected = True
+    client._kazoo.state = KazooState.CONNECTED
+    return client
+
+
+class TestZkClientInit:
+
+    def test_init_success(self):
+        from src.zk_client import ZkClient
+        mock_kazoo = MagicMock()
+        mock_kazoo.connected = True
+        mock_kazoo.start_async.return_value.wait.return_value = None
+
+        with patch('src.zk_client.KazooClient', return_value=mock_kazoo), \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
+            result = client.init()
+
+        assert result is True
+        mock_kazoo.start_async.assert_called_once()
+        mock_kazoo.add_listener.assert_called_once()
+
+    def test_init_failure_returns_false(self):
+        from src.zk_client import ZkClient
+        mock_kazoo = MagicMock()
+        mock_kazoo.connected = False
+
+        with patch('src.zk_client.KazooClient', return_value=mock_kazoo), \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
+            result = client.init()
+
+        assert result is False
+
+
+class TestZkClientIsAlive:
+
+    def test_is_alive_connected(self):
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = False
+        assert client.is_alive() is True
+
+    def test_is_alive_session_expired(self):
+        """Session expired → False even if Kazoo reports CONNECTED."""
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = True
+        assert client.is_alive() is False
+
+    def test_is_alive_suspended(self):
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.SUSPENDED
+        assert client.is_alive() is False
+
+    def test_is_alive_pure_no_side_effects(self):
+        """is_alive() must not modify flags (pure query)."""
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = True
+        client._failed_inits_count = 3
+
+        client.is_alive()
+
+        # Flags must not be cleared by is_alive — listener/reconnect owns that.
+        assert client._session_expired is True
+        assert client._failed_inits_count == 3
+
+
+class TestZkClientIsConnected:
+
+    def test_is_connected_when_connected(self):
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.CONNECTED
+        assert client.is_connected() is True
+
+    def test_is_connected_when_suspended(self):
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.SUSPENDED
+        assert client.is_connected() is False
+
+    def test_is_connected_no_side_effects(self):
+        """is_connected() must not modify state flags."""
+        client = create_mock_zk_client()
+        client._kazoo.state = KazooState.CONNECTED
+        client._session_expired = True
+        client._failed_inits_count = 5
+
+        client.is_connected()
+
+        assert client._session_expired is True
+        assert client._failed_inits_count == 5
+
+
+class TestZkClientSetStateListener:
+
+    def test_set_state_listener_replaces_existing(self):
+        client = create_mock_zk_client()
+        first = MagicMock()
+        second = MagicMock()
+        client.set_state_listener(first)
+        client.set_state_listener(second)
+        client._listener(KazooState.CONNECTED)
+        first.assert_not_called()
+        second.assert_called_once_with(ZkConnectionState.CONNECTED)
+
+
+class TestZkClientReconnect:
+
+    def test_reconnect_success(self):
+        client = create_mock_zk_client()
+        client._failed_inits_count = 3
+        client._session_expired = True
+
+        new_kazoo = MagicMock()
+        new_kazoo.connected = True
+        new_kazoo.state = KazooState.CONNECTED
+
+        with patch.object(client, '_sleep_before_reconnect'), \
+             patch('src.zk_client.KazooClient', return_value=new_kazoo), \
+             patch('src.zk_client.SequentialThreadingHandler'):
+            result = client.reconnect()
+
+        assert result is True
+        assert client._session_expired is False
+
+    def test_reconnect_failure_increments_counter(self):
+        client = create_mock_zk_client()
+        client._kazoo.connected = False
+
+        with patch.object(client, '_sleep_before_reconnect'):
+            result = client.reconnect()
+
+        assert result is False
+        assert client._session_expired is True
+        assert client._failed_inits_count == 1
+
+
+class TestZkClientClose:
+
+    def test_close_removes_listener_and_stops(self):
+        client = create_mock_zk_client()
+        client.close()
+        client._kazoo.remove_listener.assert_called_once()
+        client._kazoo.stop.assert_called_once()
+        client._kazoo.close.assert_called_once()
+
+    def test_close_handles_none_kazoo(self):
+        from src.zk_client import ZkClient
+        client = ZkClient(hosts='localhost:2181', timeout=5.0, connect_max_delay=10.0, max_delay_on_reinit=30)
+        client.close()  # should not raise
+
+
+class TestZkClientListener:
+
+    def test_listener_lost_sets_session_expired(self):
+        client = create_mock_zk_client()
+        client._session_expired = False
+        client._listener(KazooState.LOST)
+        assert client._session_expired is True
+
+    def test_listener_connected_clears_flags(self):
+        client = create_mock_zk_client()
+        client._session_expired = True
+        client._failed_inits_count = 5
+        client._listener(KazooState.CONNECTED)
+        assert client._session_expired is False
+        assert client._failed_inits_count == 0
+
+    def test_listener_calls_external_callback_with_domain_state(self):
+        """External callback receives ZkConnectionState, not KazooState."""
+        client = create_mock_zk_client()
+        callback = MagicMock()
+        client._state_listener = callback
+        client._listener(KazooState.CONNECTED)
+        callback.assert_called_once_with(ZkConnectionState.CONNECTED)
+
+    def test_listener_maps_lost_to_domain_state(self):
+        client = create_mock_zk_client()
+        callback = MagicMock()
+        client._state_listener = callback
+        client._listener(KazooState.LOST)
+        callback.assert_called_once_with(ZkConnectionState.LOST)
+
+    def test_listener_maps_suspended_to_domain_state(self):
+        client = create_mock_zk_client()
+        callback = MagicMock()
+        client._state_listener = callback
+        client._listener(KazooState.SUSPENDED)
+        callback.assert_called_once_with(ZkConnectionState.SUSPENDED)
+
+    def test_listener_no_error_when_callback_is_none(self):
+        client = create_mock_zk_client()
+        client._state_listener = None
+        client._listener(KazooState.CONNECTED)  # must not raise
+
+
+class TestZkClientStateFlags:
+
+    def test_clear_connection_state_flags(self):
+        client = create_mock_zk_client()
+        client._session_expired = True
+        client._failed_inits_count = 5
+        client._clear_connection_state_flags()
+        assert client._session_expired is False
+        assert client._failed_inits_count == 0
+
+    def test_clear_session_expired_flag_only(self):
+        client = create_mock_zk_client()
+        client._session_expired = True
+        client._failed_inits_count = 5
+        client._clear_session_expired_flag()
+        assert client._session_expired is False
+        assert client._failed_inits_count == 5
+
+
+class TestZkClientResolvePath:
+
+    def test_resolves_relative_path(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        assert client._resolve_path('leader') == '/pgconsul/leader'
+
+    def test_does_not_double_prefix(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        assert client._resolve_path('/pgconsul/leader') == '/pgconsul/leader'
+
+
+class TestZkClientDataOps:
+
+    def test_get_delegates_to_kazoo(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client._kazoo.get.return_value = (b'value', MagicMock())
+        result = client.get('leader')
+        client._kazoo.get.assert_called_once_with('/pgconsul/leader')
+        assert result == (b'value', client._kazoo.get.return_value[1])
+
+    def test_get_raises_zk_no_node_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.get.side_effect = _NoNodeError()
+            with pytest.raises(ZkNoNodeError):
+                client.get('missing')
+
+    def test_get_raises_zk_session_expired_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.SessionExpiredError', _SessionExpiredError):
+            client._kazoo.get.side_effect = _SessionExpiredError()
+            with pytest.raises(ZkSessionExpiredError):
+                client.get('leader')
+
+    def test_get_raises_zk_client_error_on_kazoo_exception(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.get.side_effect = _KazooException("conn error")
+            with pytest.raises(ZkClientError):
+                client.get('leader')
+
+    def test_write_uses_set_when_node_exists(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client.write('leader', 'host1')
+        client._kazoo.set.assert_called_once_with('/pgconsul/leader', b'host1')
+        client._kazoo.create.assert_not_called()
+
+    def test_write_falls_back_to_create_on_no_node(self):
+        _NoNode = type('NoNodeError', (Exception,), {})
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        with patch('src.zk_client.NoNodeError', _NoNode):
+            client._kazoo.set.side_effect = _NoNode()
+            client.write('leader', 'host1')
+        client._kazoo.create.assert_called_once_with('/pgconsul/leader', value=b'host1', makepath=True)
+
+    def test_write_retries_set_on_race(self):
+        """NodeExistsError during create → retry set."""
+        _NoNode = type('NoNodeError', (Exception,), {})
+        _NodeExists = type('NodeExistsError', (Exception,), {})
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        with patch('src.zk_client.NoNodeError', _NoNode), \
+             patch('src.zk_client.NodeExistsError', _NodeExists):
+            client._kazoo.set.side_effect = [_NoNode(), None]
+            client._kazoo.create.side_effect = _NodeExists()
+            client.write('leader', 'host1')
+        assert client._kazoo.set.call_count == 2
+
+    def test_write_raises_zk_session_expired(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.SessionExpiredError', _SessionExpiredError), \
+             patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.set.side_effect = _SessionExpiredError()
+            with pytest.raises(ZkSessionExpiredError):
+                client.write('leader', 'val')
+
+    def test_exists_returns_true_when_node_exists(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client._kazoo.exists.return_value = MagicMock()
+        assert client.exists('leader') is True
+
+    def test_exists_returns_false_when_absent(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client._kazoo.exists.return_value = None
+        assert client.exists('leader') is False
+
+    def test_exists_raises_zk_client_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.exists.side_effect = _KazooException("conn error")
+            with pytest.raises(ZkClientError):
+                client.exists('leader')
+
+    def test_get_children_returns_list(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client._kazoo.get_children.return_value = ['a', 'b']
+        assert client.get_children('all_hosts') == ['a', 'b']
+
+    def test_get_children_returns_empty_on_no_node(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.get_children.side_effect = _NoNodeError()
+            assert client.get_children('missing') == []
+
+    def test_get_children_raises_zk_client_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError), \
+             patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.get_children.side_effect = _KazooException("conn error")
+            with pytest.raises(ZkClientError):
+                client.get_children('leader')
+
+    def test_ensure_path_raises_zk_client_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.ensure_path.side_effect = _KazooException("conn error")
+            with pytest.raises(ZkClientError):
+                client.ensure_path('some/path')
+
+    def test_delete_success(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        assert client.delete('leader', recursive=True) is True
+        client._kazoo.delete.assert_called_once_with('/pgconsul/leader', recursive=True)
+
+    def test_delete_returns_true_on_no_node(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.delete.side_effect = _NoNodeError()
+            assert client.delete('missing') is True
+
+    def test_delete_raises_zk_client_error_on_kazoo_exception(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError), \
+             patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.delete.side_effect = _KazooException("err")
+            with pytest.raises(ZkClientError):
+                client.delete('leader')
+
+
+class TestZkClientLockRecipes:
+
+    def test_make_lock_returns_lock_handle(self):
+        from src.zk_client import LockHandle
+        client = create_mock_zk_client()
+        mock_lock = MagicMock()
+        client._kazoo.Lock.return_value = mock_lock
+        result = client.make_lock('/pgconsul/leader', 'host1')
+        client._kazoo.Lock.assert_called_once_with('/pgconsul/leader', 'host1')
+        assert isinstance(result, LockHandle)
+
+    def test_make_read_lock_returns_lock_handle(self):
+        from src.zk_client import LockHandle
+        client = create_mock_zk_client()
+        mock_lock = MagicMock()
+        client._kazoo.ReadLock.return_value = mock_lock
+        result = client.make_read_lock('/pgconsul/leader', 'host1')
+        client._kazoo.ReadLock.assert_called_once_with('/pgconsul/leader', 'host1')
+        assert isinstance(result, LockHandle)
+
+
+class TestLockHandle:
+
+    def _make_handle(self):
+        from src.zk_client import LockHandle
+        mock_lock = MagicMock()
+        return LockHandle(mock_lock), mock_lock
+
+    def test_acquire_delegates(self):
+        handle, mock_lock = self._make_handle()
+        mock_lock.acquire.return_value = True
+        assert handle.acquire(blocking=True, timeout=5) is True
+        mock_lock.acquire.assert_called_once_with(blocking=True, timeout=5)
+
+    def test_acquire_translates_lock_timeout(self):
+        handle, mock_lock = self._make_handle()
+        with patch('src.zk_client.LockTimeout', _LockTimeout):
+            mock_lock.acquire.side_effect = _LockTimeout()
+            with pytest.raises(ZkLockTimeout):
+                handle.acquire()
+
+    def test_acquire_translates_kazoo_exception(self):
+        handle, mock_lock = self._make_handle()
+        with patch('src.zk_client.KazooException', _KazooException):
+            mock_lock.acquire.side_effect = _KazooException()
+            with pytest.raises(ZkClientError):
+                handle.acquire()
+
+    def test_release_delegates(self):
+        handle, mock_lock = self._make_handle()
+        handle.release()
+        mock_lock.release.assert_called_once()
+
+    def test_release_translates_connection_closed(self):
+        handle, mock_lock = self._make_handle()
+        with patch('src.zk_client.ConnectionClosedError', _ConnectionClosedError):
+            mock_lock.release.side_effect = _ConnectionClosedError()
+            with pytest.raises(ZkConnectionClosedError):
+                handle.release()
+
+    def test_release_translates_kazoo_exception(self):
+        handle, mock_lock = self._make_handle()
+        with patch('src.zk_client.KazooException', _KazooException):
+            mock_lock.release.side_effect = _KazooException()
+            with pytest.raises(ZkClientError):
+                handle.release()
+
+    def test_contenders_delegates(self):
+        handle, mock_lock = self._make_handle()
+        mock_lock.contenders.return_value = ['host1', 'host2']
+        assert handle.contenders() == ['host1', 'host2']
+
+    def test_contenders_translates_kazoo_exception(self):
+        handle, mock_lock = self._make_handle()
+        with patch('src.zk_client.KazooException', _KazooException):
+            mock_lock.contenders.side_effect = _KazooException()
+            with pytest.raises(ZkClientError):
+                handle.contenders()

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -255,11 +255,6 @@ class TestZkClientStateFlags:
 
 class TestZkClientResolvePath:
 
-    def test_resolves_relative_path(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        assert client._resolve_path('leader') == '/pgconsul/leader'
-
     def test_does_not_double_prefix(self):
         client = create_mock_zk_client()
         client._path_prefix = '/pgconsul/'
@@ -268,13 +263,10 @@ class TestZkClientResolvePath:
 
 class TestZkClientDataOps:
 
-    def test_get_delegates_to_kazoo(self):
+    def test_get_returns_none_for_empty_node(self):
         client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client._kazoo.get.return_value = (b'value', MagicMock())
-        result = client.get('leader')
-        client._kazoo.get.assert_called_once_with('/pgconsul/leader')
-        assert result == (b'value', client._kazoo.get.return_value[1])
+        client._kazoo.get.return_value = (None, MagicMock())
+        assert client.get('leader') is None
 
     def test_get_raises_zk_no_node_error(self):
         client = create_mock_zk_client()
@@ -296,22 +288,6 @@ class TestZkClientDataOps:
             client._kazoo.get.side_effect = _KazooException("conn error")
             with pytest.raises(ZkClientError):
                 client.get('leader')
-
-    def test_write_uses_set_when_node_exists(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        client.write('leader', 'host1')
-        client._kazoo.set.assert_called_once_with('/pgconsul/leader', b'host1')
-        client._kazoo.create.assert_not_called()
-
-    def test_write_falls_back_to_create_on_no_node(self):
-        _NoNode = type('NoNodeError', (Exception,), {})
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        with patch('src.zk_client.NoNodeError', _NoNode):
-            client._kazoo.set.side_effect = _NoNode()
-            client.write('leader', 'host1')
-        client._kazoo.create.assert_called_once_with('/pgconsul/leader', value=b'host1', makepath=True)
 
     def test_write_retries_set_on_race(self):
         """NodeExistsError during create → retry set."""
@@ -379,12 +355,6 @@ class TestZkClientDataOps:
             client._kazoo.ensure_path.side_effect = _KazooException("conn error")
             with pytest.raises(ZkClientError):
                 client.ensure_path('some/path')
-
-    def test_delete_success(self):
-        client = create_mock_zk_client()
-        client._path_prefix = '/pgconsul/'
-        assert client.delete('leader', recursive=True) is True
-        client._kazoo.delete.assert_called_once_with('/pgconsul/leader', recursive=True)
 
     def test_delete_returns_true_on_no_node(self):
         client = create_mock_zk_client()
@@ -479,3 +449,64 @@ class TestLockHandle:
             mock_lock.contenders.side_effect = _KazooException()
             with pytest.raises(ZkClientError):
                 handle.contenders()
+
+
+class TestZkClientGetMtime:
+
+    def test_get_mtime_returns_float(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        stat = MagicMock()
+        stat.last_modified = 1234567890.5
+        client._kazoo.get.return_value = (b'data', stat)
+        assert client.get_mtime('leader') == 1234567890.5
+
+    def test_get_mtime_returns_none_on_no_node(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.get.side_effect = _NoNodeError()
+            assert client.get_mtime('missing') is None
+
+    def test_get_mtime_returns_none_when_stat_is_none(self):
+        client = create_mock_zk_client()
+        client._kazoo.get.return_value = (b'data', None)
+        assert client.get_mtime('leader') is None
+
+    def test_get_mtime_raises_zk_client_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.get.side_effect = _KazooException("err")
+            with pytest.raises(ZkClientError):
+                client.get_mtime('leader')
+
+
+class TestZkClientLockVersion:
+
+    def test_lock_version_returns_min_sequence(self):
+        client = create_mock_zk_client()
+        client._path_prefix = '/pgconsul/'
+        client._kazoo.get_children.return_value = ['host1__0000000003', 'host2__0000000001', 'host3__0000000002']
+        assert client.lock_version('/pgconsul/leader') == '0000000001'
+
+    def test_lock_version_returns_none_when_no_children(self):
+        client = create_mock_zk_client()
+        client._kazoo.get_children.return_value = []
+        assert client.lock_version('/pgconsul/leader') is None
+
+    def test_lock_version_returns_none_on_no_node(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.NoNodeError', _NoNodeError):
+            client._kazoo.get_children.side_effect = _NoNodeError()
+            assert client.lock_version('/pgconsul/leader') is None
+
+    def test_lock_version_raises_zk_client_error(self):
+        client = create_mock_zk_client()
+        with patch('src.zk_client.KazooException', _KazooException):
+            client._kazoo.get_children.side_effect = _KazooException("err")
+            with pytest.raises(ZkClientError):
+                client.lock_version('/pgconsul/leader')
+
+    def test_lock_version_single_child(self):
+        client = create_mock_zk_client()
+        client._kazoo.get_children.return_value = ['host1__0000000007']
+        assert client.lock_version('/pgconsul/leader') == '0000000007'

--- a/tests/unit/test_zk_client.py
+++ b/tests/unit/test_zk_client.py
@@ -596,12 +596,9 @@ class TestWrite:
 
     def test_write_create_then_node_exists_race(self, client):
         from kazoo.exceptions import NoNodeError, NodeExistsError
-        client._kazoo.set.side_effect = NoNodeError('missing')
-        client._kazoo.create.side_effect = NodeExistsError('exists')
-        client._kazoo.set.return_value = _make_stat()
         # First set raises NoNodeError, create raises NodeExistsError, second set succeeds.
-        # Need set to succeed on second call.
         client._kazoo.set.side_effect = [NoNodeError('missing'), _make_stat()]
+        client._kazoo.create.side_effect = NodeExistsError('exists')
         assert client.write('master', 'value') is True
         assert client._kazoo.set.call_count == 2
 

--- a/tests/unit/test_zk_delete.py
+++ b/tests/unit/test_zk_delete.py
@@ -1,0 +1,89 @@
+# encoding: utf-8
+"""
+Regression tests for Zookeeper.delete() error-handling contract.
+
+Before the fix, ZkClient.delete() raised ZkClientError on failure but
+Zookeeper.delete() did not catch it, so callers expecting a bool would
+receive an uncaught exception. After the fix Zookeeper.delete() catches
+ZkClientError and returns False, so callers in utils.py / cli.py behave
+correctly.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestZookeeperDelete:
+    """Unit tests for Zookeeper.delete() error-handling."""
+
+    def test_delete_returns_true_on_success(self, zk):
+        """delete() returns True when ZkClient.delete succeeds."""
+        zk._zk_client.delete = MagicMock(return_value=True)
+        assert zk.delete('some/path') is True
+
+    def test_delete_returns_false_on_zk_client_error(self, zk):
+        """delete() returns False (not raises) when ZkClientError is raised."""
+        from src.zk_client import ZkClientError
+        zk._zk_client.delete = MagicMock(side_effect=ZkClientError('connection lost'))
+        result = zk.delete('some/path')
+        assert result is False
+
+    def test_delete_recursive_passed_to_client(self, zk):
+        """delete() forwards recursive=True to ZkClient."""
+        zk._zk_client.delete = MagicMock(return_value=True)
+        zk.delete('some/path', recursive=True)
+        zk._zk_client.delete.assert_called_once_with('some/path', recursive=True)
+
+    def test_delete_logs_exception_on_error(self, zk):
+        """delete() logs the exception when ZkClientError occurs."""
+        from src.zk_client import ZkClientError
+        zk._zk_client.delete = MagicMock(side_effect=ZkClientError('timeout'))
+        with patch('src.zk.logging') as mock_log:
+            zk.delete('some/path')
+            mock_log.exception.assert_called_once()
+
+
+class TestZookeeperDeleteMethods:
+    """Tests that delete_*() -> bool methods return bool even on ZkClientError."""
+
+    def _make_delete_error(self, zk):
+        from src.zk_client import ZkClientError
+        zk.delete = MagicMock(return_value=False)
+
+    def test_delete_failover_state_returns_false_on_error(self, zk):
+        """delete_failover_state() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        result = zk.delete_failover_state()
+        assert result is False
+
+    def test_delete_current_promoting_host_returns_false_on_error(self, zk):
+        """delete_current_promoting_host() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        result = zk.delete_current_promoting_host()
+        assert result is False
+
+    def test_delete_failover_must_be_reset_returns_false_on_error(self, zk):
+        """delete_failover_must_be_reset() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        result = zk.delete_failover_must_be_reset()
+        assert result is False
+
+    def test_delete_maintenance_returns_false_on_error(self, zk):
+        """delete_maintenance() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        result = zk.delete_maintenance()
+        assert result is False
+
+    def test_delete_host_op_returns_false_on_error(self, zk):
+        """delete_host_op() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        result = zk.delete_host_op('host1')
+        assert result is False
+
+    def test_delete_election_vote_returns_false_on_error(self, zk):
+        """delete_election_vote() returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
+        with patch('src.zk.helpers.get_hostname', return_value='host1'):
+            result = zk.delete_election_vote('host1')
+        assert result is False
+
+

--- a/tests/unit/test_zk_failover.py
+++ b/tests/unit/test_zk_failover.py
@@ -48,6 +48,12 @@ class TestZookeeperFailoverState:
         result = zk.write_failover_state('promoting')
         assert result is False
 
+    def test_write_failover_state_no_lock_returns_false(self, zk):
+        """Test write_failover_state returns False when write() returns False (no lock holder)."""
+        zk.write = MagicMock(return_value=False)
+        result = zk.write_failover_state('promoting')
+        assert result is False
+
     # === delete_failover_state tests ===
 
     def test_delete_failover_state_calls_delete(self, zk):

--- a/tests/unit/test_zk_failover.py
+++ b/tests/unit/test_zk_failover.py
@@ -1,0 +1,228 @@
+# encoding: utf-8
+"""
+Unit tests for Zookeeper failover state business methods.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestZookeeperFailoverState:
+    """Tests for failover state methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_failover_state tests ===
+
+    def test_get_failover_state_returns_value(self, zk):
+        """Test get_failover_state returns value from noexcept_get."""
+        zk.noexcept_get = MagicMock(return_value='promoting')
+        result = zk.get_failover_state()
+        assert result == 'promoting'
+        zk.noexcept_get.assert_called_once_with('failover_state')
+
+    def test_get_failover_state_returns_none(self, zk):
+        """Test get_failover_state returns None when not set."""
+        zk.noexcept_get = MagicMock(return_value=None)
+        result = zk.get_failover_state()
+        assert result is None
+
+    # === write_failover_state tests ===
+
+    def test_write_failover_state_calls_write(self, zk):
+        """Test write_failover_state writes state string."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_failover_state('promoting')
+        assert result is True
+        zk.write.assert_called_once_with('failover_state', 'promoting')
+
+    def test_write_failover_state_with_finished(self, zk):
+        """Test write_failover_state with 'finished' state."""
+        zk.write = MagicMock(return_value=True)
+        zk.write_failover_state('finished')
+        zk.write.assert_called_once_with('failover_state', 'finished')
+
+    def test_write_failover_state_failure_returns_false(self, zk):
+        """Test write_failover_state returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_failover_state('promoting')
+        assert result is False
+
+    # === delete_failover_state tests ===
+
+    def test_delete_failover_state_calls_delete(self, zk):
+        """Test delete_failover_state calls delete."""
+        zk.delete = MagicMock()
+        result = zk.delete_failover_state()
+        assert result is True
+        zk.delete.assert_called_once_with('failover_state')
+
+    def test_delete_failover_state_failure_returns_false(self, zk):
+        """Test delete_failover_state returns False on exception."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_failover_state()
+        assert result is False
+
+    # === write_current_promoting_host tests ===
+
+    def test_write_current_promoting_host_calls_write(self, zk):
+        """Test write_current_promoting_host writes hostname."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_current_promoting_host('test-host')
+        assert result is True
+        zk.write.assert_called_once_with('current_promoting_host', 'test-host')
+
+    def test_write_current_promoting_host_uses_current_hostname(self, zk):
+        """Test write_current_promoting_host uses helpers.get_hostname() when None."""
+        zk.write = MagicMock(return_value=True)
+        with patch('src.zk.helpers.get_hostname', return_value='my-host'):
+            zk.write_current_promoting_host()
+            zk.write.assert_called_once_with('current_promoting_host', 'my-host')
+
+    def test_write_current_promoting_host_failure_returns_false(self, zk):
+        """Test write_current_promoting_host returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_current_promoting_host('test-host')
+        assert result is False
+
+    # === delete_current_promoting_host tests ===
+
+    def test_delete_current_promoting_host_calls_delete(self, zk):
+        """Test delete_current_promoting_host calls delete."""
+        zk.delete = MagicMock()
+        result = zk.delete_current_promoting_host()
+        assert result is True
+        zk.delete.assert_called_once_with('current_promoting_host')
+
+    def test_delete_current_promoting_host_failure_returns_false(self, zk):
+        """Test delete_current_promoting_host returns False on exception."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_current_promoting_host()
+        assert result is False
+
+    # === ensure_failover_must_be_reset tests ===
+
+    def test_ensure_failover_must_be_reset_success(self, zk):
+        """Test ensure_failover_must_be_reset returns True on success."""
+        zk.ensure_path = MagicMock(return_value='result')
+        result = zk.ensure_failover_must_be_reset()
+        assert result is True
+        zk.ensure_path.assert_called_once_with('failover_must_be_reset')
+
+    def test_ensure_failover_must_be_reset_failure_returns_false(self, zk):
+        """Test ensure_failover_must_be_reset returns False when ensure_path returns None."""
+        zk.ensure_path = MagicMock(return_value=None)
+        result = zk.ensure_failover_must_be_reset()
+        assert result is False
+
+    # === delete_failover_must_be_reset tests ===
+
+    def test_delete_failover_must_be_reset_calls_delete(self, zk):
+        """Test delete_failover_must_be_reset calls delete."""
+        zk.delete = MagicMock()
+        result = zk.delete_failover_must_be_reset()
+        assert result is True
+        zk.delete.assert_called_once_with('failover_must_be_reset')
+
+    def test_delete_failover_must_be_reset_failure_returns_false(self, zk):
+        """Test delete_failover_must_be_reset returns False on exception."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_failover_must_be_reset()
+        assert result is False
+
+    # === get_last_failover_time tests ===
+
+    def test_get_last_failover_time_returns_float(self, zk):
+        """Test get_last_failover_time returns float timestamp."""
+        expected = 1234567890.123
+        zk.get = MagicMock(return_value=expected)
+        result = zk.get_last_failover_time()
+        assert result == expected
+        zk.get.assert_called_once_with('last_failover_time', preproc=float)
+
+    def test_get_last_failover_time_returns_none(self, zk):
+        """Test get_last_failover_time returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_last_failover_time()
+        assert result is None
+
+    # === write_last_failover_time tests ===
+
+    def test_write_last_failover_time_calls_write(self, zk):
+        """Test write_last_failover_time writes current time as float."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_last_failover_time()
+        assert result is True
+        call_args = zk.write.call_args
+        assert call_args[0][0] == 'last_failover_time'
+        assert isinstance(call_args[0][1], float)
+        assert call_args[1]['need_lock'] is False
+
+    def test_write_last_failover_time_failure_returns_false(self, zk):
+        """Test write_last_failover_time returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_last_failover_time()
+        assert result is False
+
+    # === get_last_primary_availability_time tests ===
+
+    def test_get_last_primary_availability_time_returns_float(self, zk):
+        """Test get_last_primary_availability_time returns float timestamp."""
+        expected = 1234567890.123
+        zk.noexcept_get = MagicMock(return_value=expected)
+        result = zk.get_last_primary_availability_time()
+        assert result == expected
+        zk.noexcept_get.assert_called_once_with('last_master_activity_time', preproc=float)
+
+    def test_get_last_primary_availability_time_returns_none(self, zk):
+        """Test get_last_primary_availability_time returns None on error."""
+        zk.noexcept_get = MagicMock(return_value=None)
+        result = zk.get_last_primary_availability_time()
+        assert result is None
+
+    # === write_last_primary_availability_time tests ===
+
+    def test_write_last_primary_availability_time_calls_write(self, zk):
+        """Test write_last_primary_availability_time writes current time."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_last_primary_availability_time()
+        assert result is True
+        call_args = zk.write.call_args
+        assert call_args[0][0] == 'last_master_activity_time'
+        assert isinstance(call_args[0][1], float)
+
+    def test_write_last_primary_availability_time_failure_returns_false(self, zk):
+        """Test write_last_primary_availability_time returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_last_primary_availability_time()
+        assert result is False
+
+    # === get_last_switchover_time tests ===
+
+    def test_get_last_switchover_time_returns_float(self, zk):
+        """Test get_last_switchover_time returns float timestamp."""
+        expected = 1234567890.123
+        zk.get = MagicMock(return_value=expected)
+        result = zk.get_last_switchover_time()
+        assert result == expected
+        zk.get.assert_called_once_with('last_switchover_time', preproc=float)
+
+    def test_get_last_switchover_time_returns_none(self, zk):
+        """Test get_last_switchover_time returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_last_switchover_time()
+        assert result is None

--- a/tests/unit/test_zk_failover.py
+++ b/tests/unit/test_zk_failover.py
@@ -52,14 +52,14 @@ class TestZookeeperFailoverState:
 
     def test_delete_failover_state_calls_delete(self, zk):
         """Test delete_failover_state calls delete."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_failover_state()
         assert result is True
         zk.delete.assert_called_once_with('failover_state')
 
     def test_delete_failover_state_failure_returns_false(self, zk):
-        """Test delete_failover_state returns False on exception."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        """Test delete_failover_state returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_failover_state()
         assert result is False
 
@@ -89,14 +89,14 @@ class TestZookeeperFailoverState:
 
     def test_delete_current_promoting_host_calls_delete(self, zk):
         """Test delete_current_promoting_host calls delete."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_current_promoting_host()
         assert result is True
         zk.delete.assert_called_once_with('current_promoting_host')
 
     def test_delete_current_promoting_host_failure_returns_false(self, zk):
-        """Test delete_current_promoting_host returns False on exception."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        """Test delete_current_promoting_host returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_current_promoting_host()
         assert result is False
 
@@ -119,14 +119,14 @@ class TestZookeeperFailoverState:
 
     def test_delete_failover_must_be_reset_calls_delete(self, zk):
         """Test delete_failover_must_be_reset calls delete."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_failover_must_be_reset()
         assert result is True
         zk.delete.assert_called_once_with('failover_must_be_reset')
 
     def test_delete_failover_must_be_reset_failure_returns_false(self, zk):
-        """Test delete_failover_must_be_reset returns False on exception."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        """Test delete_failover_must_be_reset returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_failover_must_be_reset()
         assert result is False
 

--- a/tests/unit/test_zk_failover.py
+++ b/tests/unit/test_zk_failover.py
@@ -3,28 +3,14 @@
 Unit tests for Zookeeper failover state business methods.
 """
 
-import time
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 class TestZookeeperFailoverState:
-    """Tests for failover state methods in Zookeeper class."""
+    """Tests for failover state methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_failover_state tests ===
 
@@ -149,14 +135,14 @@ class TestZookeeperFailoverState:
     def test_get_last_failover_time_returns_float(self, zk):
         """Test get_last_failover_time returns float timestamp."""
         expected = 1234567890.123
-        zk.get = MagicMock(return_value=expected)
+        zk.noexcept_get = MagicMock(return_value=expected)
         result = zk.get_last_failover_time()
         assert result == expected
-        zk.get.assert_called_once_with('last_failover_time', preproc=float)
+        zk.noexcept_get.assert_called_once_with('last_failover_time', preproc=float)
 
     def test_get_last_failover_time_returns_none(self, zk):
         """Test get_last_failover_time returns None when not set."""
-        zk.get = MagicMock(return_value=None)
+        zk.noexcept_get = MagicMock(return_value=None)
         result = zk.get_last_failover_time()
         assert result is None
 

--- a/tests/unit/test_zk_failover.py
+++ b/tests/unit/test_zk_failover.py
@@ -196,19 +196,3 @@ class TestZookeeperFailoverState:
         zk.write = MagicMock(side_effect=Exception('ZK error'))
         result = zk.write_last_primary_availability_time()
         assert result is False
-
-    # === get_last_switchover_time tests ===
-
-    def test_get_last_switchover_time_returns_float(self, zk):
-        """Test get_last_switchover_time returns float timestamp."""
-        expected = 1234567890.123
-        zk.get = MagicMock(return_value=expected)
-        result = zk.get_last_switchover_time()
-        assert result == expected
-        zk.get.assert_called_once_with('last_switchover_time', preproc=float)
-
-    def test_get_last_switchover_time_returns_none(self, zk):
-        """Test get_last_switchover_time returns None when not set."""
-        zk.get = MagicMock(return_value=None)
-        result = zk.get_last_switchover_time()
-        assert result is None

--- a/tests/unit/test_zk_host_methods.py
+++ b/tests/unit/test_zk_host_methods.py
@@ -104,7 +104,7 @@ class TestZookeeperHostMethods:
     def test_delete_host_ha_success(self, zk):
         """Test delete_host_ha returns True when delete succeeds."""
         zk.exists_path = MagicMock(return_value=True)
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_host_ha('test-host')
         assert result is True
         zk.delete.assert_called_once_with('all_hosts/test-host/ha')
@@ -118,9 +118,9 @@ class TestZookeeperHostMethods:
         zk.delete.assert_not_called()
 
     def test_delete_host_ha_failure_returns_false(self, zk):
-        """Test delete_host_ha returns False when delete fails."""
+        """Test delete_host_ha returns False when delete returns False (ZkClientError caught inside delete)."""
         zk.exists_path = MagicMock(return_value=True)
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_host_ha('test-host')
         assert result is False
 

--- a/tests/unit/test_zk_host_methods.py
+++ b/tests/unit/test_zk_host_methods.py
@@ -9,25 +9,12 @@ write_host_wal_receiver, get_host_wal_receiver
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestZookeeperHostMethods:
-    """Tests for host-level business methods in Zookeeper class."""
+    """Tests for host-level business methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_host_op_path tests ===
 
@@ -129,13 +116,23 @@ class TestZookeeperHostMethods:
 
     def test_delete_host_ha_success(self, zk):
         """Test delete_host_ha returns True when delete succeeds."""
+        zk.exists_path = MagicMock(return_value=True)
         zk.delete = MagicMock()
         result = zk.delete_host_ha('test-host')
         assert result is True
         zk.delete.assert_called_once_with('all_hosts/test-host/ha')
 
+    def test_delete_host_ha_returns_true_when_path_not_exists(self, zk):
+        """Test delete_host_ha returns True and does not call delete when path does not exist."""
+        zk.exists_path = MagicMock(return_value=False)
+        zk.delete = MagicMock()
+        result = zk.delete_host_ha('test-host')
+        assert result is True
+        zk.delete.assert_not_called()
+
     def test_delete_host_ha_failure_returns_false(self, zk):
         """Test delete_host_ha returns False when delete fails."""
+        zk.exists_path = MagicMock(return_value=True)
         zk.delete = MagicMock(side_effect=Exception('ZK error'))
         result = zk.delete_host_ha('test-host')
         assert result is False

--- a/tests/unit/test_zk_host_methods.py
+++ b/tests/unit/test_zk_host_methods.py
@@ -79,14 +79,14 @@ class TestZookeeperHostMethods:
 
     def test_delete_host_op_calls_delete(self, zk):
         """Test delete_host_op calls delete with correct path."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_host_op('test-host')
         assert result is True
         zk.delete.assert_called_once_with('all_hosts/test-host/op')
 
-    def test_delete_host_op_returns_false_on_exception(self, zk):
+    def test_delete_host_op_returns_false_on_failure(self, zk):
         """Test delete_host_op returns False when delete fails."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_host_op('test-host')
         assert result is False
 

--- a/tests/unit/test_zk_host_methods.py
+++ b/tests/unit/test_zk_host_methods.py
@@ -16,19 +16,6 @@ class TestZookeeperHostMethods:
     The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
     """
 
-    # === get_host_op_path tests ===
-
-    def test_get_host_op_path_with_hostname(self, zk):
-        """Test get_host_op_path returns correct path for given hostname."""
-        path = zk.get_host_op_path('test-host')
-        assert path == 'all_hosts/test-host/op'
-
-    def test_get_host_op_path_without_hostname_uses_current(self, zk):
-        """Test get_host_op_path uses current hostname when None."""
-        with patch('src.zk.helpers.get_hostname', return_value='current-host'):
-            path = zk.get_host_op_path()
-            assert path == 'all_hosts/current-host/op'
-
     # === get_host_op tests ===
 
     def test_get_host_op_returns_value(self, zk):

--- a/tests/unit/test_zk_host_methods.py
+++ b/tests/unit/test_zk_host_methods.py
@@ -1,0 +1,217 @@
+# encoding: utf-8
+"""
+Unit tests for Zookeeper host-level business methods.
+Tests methods: get_host_op_path, get_host_op, write_host_op, delete_host_op,
+ensure_host_ha, delete_host_ha, write_host_replics_info, get_host_replics_info,
+write_host_wal_receiver, get_host_wal_receiver
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestZookeeperHostMethods:
+    """Tests for host-level business methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_host_op_path tests ===
+
+    def test_get_host_op_path_with_hostname(self, zk):
+        """Test get_host_op_path returns correct path for given hostname."""
+        path = zk.get_host_op_path('test-host')
+        assert path == 'all_hosts/test-host/op'
+
+    def test_get_host_op_path_without_hostname_uses_current(self, zk):
+        """Test get_host_op_path uses current hostname when None."""
+        with patch('src.zk.helpers.get_hostname', return_value='current-host'):
+            path = zk.get_host_op_path()
+            assert path == 'all_hosts/current-host/op'
+
+    # === get_host_op tests ===
+
+    def test_get_host_op_returns_value(self, zk):
+        """Test get_host_op returns value from noexcept_get."""
+        zk.noexcept_get = MagicMock(return_value='promoting')
+        result = zk.get_host_op('test-host')
+        assert result == 'promoting'
+        zk.noexcept_get.assert_called_once_with('all_hosts/test-host/op')
+
+    def test_get_host_op_default_hostname(self, zk):
+        """Test get_host_op uses current hostname when None."""
+        zk.noexcept_get = MagicMock(return_value='rewind')
+        with patch('src.zk.helpers.get_hostname', return_value='my-host'):
+            result = zk.get_host_op()
+            assert result == 'rewind'
+            zk.noexcept_get.assert_called_once_with('all_hosts/my-host/op')
+
+    def test_get_host_op_returns_none_when_not_found(self, zk):
+        """Test get_host_op returns None when node doesn't exist."""
+        zk.noexcept_get = MagicMock(return_value=None)
+        result = zk.get_host_op('missing-host')
+        assert result is None
+
+    # === write_host_op tests ===
+
+    def test_write_host_op_calls_noexcept_write(self, zk):
+        """Test write_host_op calls noexcept_write with correct arguments."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        result = zk.write_host_op('promoting', 'test-host')
+        assert result is True
+        zk.noexcept_write.assert_called_once_with('all_hosts/test-host/op', 'promoting', need_lock=False)
+
+    def test_write_host_op_need_lock_false(self, zk):
+        """Test write_host_op always uses need_lock=False."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        zk.write_host_op('rewind', 'test-host')
+        call_kwargs = zk.noexcept_write.call_args[1]
+        assert call_kwargs['need_lock'] is False
+
+    def test_write_host_op_default_hostname(self, zk):
+        """Test write_host_op uses current hostname when None."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        with patch('src.zk.helpers.get_hostname', return_value='my-host'):
+            zk.write_host_op('promoting')
+            zk.noexcept_write.assert_called_once_with('all_hosts/my-host/op', 'promoting', need_lock=False)
+
+    # === delete_host_op tests ===
+
+    def test_delete_host_op_calls_delete(self, zk):
+        """Test delete_host_op calls delete with correct path."""
+        zk.delete = MagicMock()
+        result = zk.delete_host_op('test-host')
+        assert result is True
+        zk.delete.assert_called_once_with('all_hosts/test-host/op')
+
+    def test_delete_host_op_returns_false_on_exception(self, zk):
+        """Test delete_host_op returns False when delete fails."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_host_op('test-host')
+        assert result is False
+
+    # === ensure_host_ha tests ===
+
+    def test_ensure_host_ha_success(self, zk):
+        """Test ensure_host_ha returns True when ensure_path succeeds."""
+        zk.ensure_path = MagicMock(return_value='some_result')
+        result = zk.ensure_host_ha('test-host')
+        assert result is True
+        zk.ensure_path.assert_called_once_with('all_hosts/test-host/ha')
+
+    def test_ensure_host_ha_failure(self, zk):
+        """Test ensure_host_ha returns False when ensure_path returns None."""
+        zk.ensure_path = MagicMock(return_value=None)
+        result = zk.ensure_host_ha('test-host')
+        assert result is False
+
+    def test_ensure_host_ha_default_hostname(self, zk):
+        """Test ensure_host_ha uses current hostname when None."""
+        zk.ensure_path = MagicMock(return_value='result')
+        with patch('src.zk.helpers.get_hostname', return_value='my-host'):
+            zk.ensure_host_ha()
+            zk.ensure_path.assert_called_once_with('all_hosts/my-host/ha')
+
+    # === delete_host_ha tests ===
+
+    def test_delete_host_ha_success(self, zk):
+        """Test delete_host_ha returns True when delete succeeds."""
+        zk.delete = MagicMock()
+        result = zk.delete_host_ha('test-host')
+        assert result is True
+        zk.delete.assert_called_once_with('all_hosts/test-host/ha')
+
+    def test_delete_host_ha_failure_returns_false(self, zk):
+        """Test delete_host_ha returns False when delete fails."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_host_ha('test-host')
+        assert result is False
+
+    # === write_host_replics_info tests ===
+
+    def test_write_host_replics_info_serializes_json(self, zk):
+        """Test write_host_replics_info serializes data as JSON."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        replics_info = [{'host': 'replica1', 'lag': 100}]
+        result = zk.write_host_replics_info(replics_info, 'test-host')
+        assert result is True
+        zk.noexcept_write.assert_called_once_with(
+            'all_hosts/test-host/replics_info',
+            replics_info,
+            preproc=json.dumps,
+            need_lock=False
+        )
+
+    def test_write_host_replics_info_need_lock_false(self, zk):
+        """Test write_host_replics_info always uses need_lock=False."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        zk.write_host_replics_info([], 'test-host')
+        call_kwargs = zk.noexcept_write.call_args[1]
+        assert call_kwargs['need_lock'] is False
+
+    # === get_host_replics_info tests ===
+
+    def test_get_host_replics_info_parses_json(self, zk):
+        """Test get_host_replics_info parses JSON response."""
+        expected_data = [{'host': 'replica1', 'lag': 100}]
+        zk.get = MagicMock(return_value=expected_data)
+        result = zk.get_host_replics_info('test-host')
+        assert result == expected_data
+        zk.get.assert_called_once_with('all_hosts/test-host/replics_info', preproc=json.loads)
+
+    def test_get_host_replics_info_returns_none_on_error(self, zk):
+        """Test get_host_replics_info returns None when get fails."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_host_replics_info('test-host')
+        assert result is None
+
+    # === write_host_wal_receiver tests ===
+
+    def test_write_host_wal_receiver_serializes_json(self, zk):
+        """Test write_host_wal_receiver serializes data as JSON."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        wal_info = {'status': 'streaming', 'pid': 12345}
+        result = zk.write_host_wal_receiver(wal_info, 'test-host')
+        assert result is True
+        zk.noexcept_write.assert_called_once_with(
+            'all_hosts/test-host/wal_receiver',
+            wal_info,
+            preproc=json.dumps,
+            need_lock=False
+        )
+
+    def test_write_host_wal_receiver_need_lock_false(self, zk):
+        """Test write_host_wal_receiver always uses need_lock=False."""
+        zk.noexcept_write = MagicMock(return_value=True)
+        zk.write_host_wal_receiver({}, 'test-host')
+        call_kwargs = zk.noexcept_write.call_args[1]
+        assert call_kwargs['need_lock'] is False
+
+    # === get_host_wal_receiver tests ===
+
+    def test_get_host_wal_receiver_parses_json(self, zk):
+        """Test get_host_wal_receiver parses JSON response."""
+        expected_data = {'status': 'streaming', 'pid': 12345}
+        zk.get = MagicMock(return_value=expected_data)
+        result = zk.get_host_wal_receiver('test-host')
+        assert result == expected_data
+        zk.get.assert_called_once_with('all_hosts/test-host/wal_receiver', preproc=json.loads)
+
+    def test_get_host_wal_receiver_returns_none_on_error(self, zk):
+        """Test get_host_wal_receiver returns None when get fails."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_host_wal_receiver('test-host')
+        assert result is None

--- a/tests/unit/test_zk_listener_reset.py
+++ b/tests/unit/test_zk_listener_reset.py
@@ -1,0 +1,90 @@
+# encoding: utf-8
+"""
+Tests for _failed_inits_count reset on kazoo auto-reconnect (SUSPENDED → CONNECTED).
+
+Problem: if kazoo self-heals the connection (SUSPENDED → CONNECTED),
+Zookeeper.reconnect() is never called, so _failed_inits_count was not reset.
+This caused the exponential backoff to start from an accumulated value on the
+next disconnection event.
+
+Coverage split:
+- ZkClient._listener(CONNECTED) resets _failed_inits_count + _session_expired
+  → tested here via zk_client fixture (ZkClient-level) and as a regression
+    in test_zk_client.py::TestListener::test_listener_connected_clears_flags.
+- Zookeeper._listener(LOST) clears all locks
+  → tested here via zk fixture (Zookeeper-level).
+"""
+
+from unittest.mock import MagicMock
+
+from kazoo.client import KazooState
+
+from src.zk_client import ZkConnectionState
+
+
+class TestZkClientListenerResetsBackoffCounter:
+    """ZkClient._listener(CONNECTED) must reset _failed_inits_count."""
+
+    def test_connected_resets_failed_inits_count(self, zk_client):
+        zk_client._failed_inits_count = 5
+        zk_client._listener(KazooState.CONNECTED)
+        assert zk_client._failed_inits_count == 0
+
+    def test_suspended_does_not_reset_failed_inits_count(self, zk_client):
+        zk_client._failed_inits_count = 5
+        zk_client._listener(KazooState.SUSPENDED)
+        assert zk_client._failed_inits_count == 5
+
+    def test_lost_does_not_reset_failed_inits_count(self, zk_client):
+        zk_client._failed_inits_count = 5
+        zk_client._listener(KazooState.LOST)
+        assert zk_client._failed_inits_count == 5
+
+    def test_connected_noop_when_count_is_zero(self, zk_client):
+        zk_client._failed_inits_count = 0
+        zk_client._listener(KazooState.CONNECTED)
+        assert zk_client._failed_inits_count == 0
+
+    def test_after_failures_listener_connected_resets_count(self, zk_client):
+        """Full scenario: failures accumulate, then kazoo auto-reconnects via _listener."""
+        # Simulate state after three failed reconnects (reconnect() itself
+        # is tested in test_zk_client.py::TestZkClientReconnect).
+        zk_client._failed_inits_count = 3
+
+        # Kazoo self-heals; ZkClient._listener is called with CONNECTED
+        zk_client._listener(KazooState.CONNECTED)
+        assert zk_client._failed_inits_count == 0
+
+        # Next backoff would start from base_delay (2^0), not 2^3
+        max_sleep = min(zk_client._base_delay * 2 ** zk_client._failed_inits_count,
+                        zk_client.config.max_delay_on_reinit)
+        assert max_sleep == zk_client._base_delay
+
+    def test_connected_also_clears_session_expired(self, zk_client):
+        """_listener(CONNECTED) must clear _session_expired too."""
+        zk_client._session_expired = True
+        zk_client._failed_inits_count = 2
+        zk_client._listener(KazooState.CONNECTED)
+        assert zk_client._session_expired is False
+        assert zk_client._failed_inits_count == 0
+
+
+class TestZookeeperListenerLockCleanup:
+    """Zookeeper._listener(LOST) must clear the lock registry."""
+
+    def test_lost_clears_all_locks(self, zk):
+        zk._locks = {'leader': MagicMock(), 'switchover/lock': MagicMock()}
+        zk._listener(ZkConnectionState.LOST)
+        assert zk._locks == {}
+
+    def test_suspended_does_not_clear_locks(self, zk):
+        sentinel = {'leader': MagicMock()}
+        zk._locks = dict(sentinel)
+        zk._listener(ZkConnectionState.SUSPENDED)
+        assert list(zk._locks.keys()) == list(sentinel.keys())
+
+    def test_connected_does_not_clear_locks(self, zk):
+        sentinel = {'leader': MagicMock()}
+        zk._locks = dict(sentinel)
+        zk._listener(ZkConnectionState.CONNECTED)
+        assert list(zk._locks.keys()) == list(sentinel.keys())

--- a/tests/unit/test_zk_maintenance_timeline.py
+++ b/tests/unit/test_zk_maintenance_timeline.py
@@ -1,0 +1,249 @@
+# encoding: utf-8
+"""
+Unit tests for Zookeeper maintenance, timeline and replics_info business methods.
+"""
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestZookeeperMaintenance:
+    """Tests for maintenance methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_maintenance_status tests ===
+
+    def test_get_maintenance_status_returns_value(self, zk):
+        """Test get_maintenance_status returns value from get."""
+        zk.get = MagicMock(return_value='enabled')
+        result = zk.get_maintenance_status()
+        assert result == 'enabled'
+        zk.get.assert_called_once_with('maintenance')
+
+    def test_get_maintenance_status_returns_none(self, zk):
+        """Test get_maintenance_status returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_maintenance_status()
+        assert result is None
+
+    # === delete_maintenance tests ===
+
+    def test_delete_maintenance_success(self, zk):
+        """Test delete_maintenance calls delete with recursive=True."""
+        zk.delete = MagicMock()
+        result = zk.delete_maintenance()
+        assert result is True
+        zk.delete.assert_called_once_with('maintenance', recursive=True)
+
+    def test_delete_maintenance_failure_returns_false(self, zk):
+        """Test delete_maintenance returns False on exception."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_maintenance()
+        assert result is False
+
+    # === get_maintenance_ts tests ===
+
+    def test_get_maintenance_ts_returns_value(self, zk):
+        """Test get_maintenance_ts returns timestamp string."""
+        zk.get = MagicMock(return_value='1234567890.123')
+        result = zk.get_maintenance_ts()
+        assert result == '1234567890.123'
+        zk.get.assert_called_once_with('maintenance/ts')
+
+    # === write_maintenance_ts tests ===
+
+    def test_write_maintenance_ts_calls_write(self, zk):
+        """Test write_maintenance_ts writes current time."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_maintenance_ts()
+        assert result is True
+        zk.write.assert_called_once()
+        call_args = zk.write.call_args
+        assert call_args[0][0] == 'maintenance/ts'
+        assert isinstance(call_args[0][1], float)
+        assert call_args[1]['need_lock'] is False
+
+    def test_write_maintenance_ts_failure_returns_false(self, zk):
+        """Test write_maintenance_ts returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_maintenance_ts()
+        assert result is False
+
+    # === get_maintenance_primary tests ===
+
+    def test_get_maintenance_primary_returns_value(self, zk):
+        """Test get_maintenance_primary returns hostname."""
+        zk.get = MagicMock(return_value='primary-host.example.com')
+        result = zk.get_maintenance_primary()
+        assert result == 'primary-host.example.com'
+        zk.get.assert_called_once_with('maintenance/master')
+
+    # === write_maintenance_primary tests ===
+
+    def test_write_maintenance_primary_calls_write(self, zk):
+        """Test write_maintenance_primary writes hostname."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_maintenance_primary('new-primary.example.com')
+        assert result is True
+        zk.write.assert_called_once_with('maintenance/master', 'new-primary.example.com', need_lock=False)
+
+    def test_write_maintenance_primary_failure_returns_false(self, zk):
+        """Test write_maintenance_primary returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_maintenance_primary('test-host')
+        assert result is False
+
+    # === write_host_maintenance_enabled tests ===
+
+    def test_write_host_maintenance_enabled_calls_write(self, zk):
+        """Test write_host_maintenance_enabled writes 'enable'."""
+        zk.write = MagicMock(return_value=True)
+        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
+        result = zk.write_host_maintenance_enabled('test-host')
+        assert result is True
+        zk.write.assert_called_once_with('maintenance/test-host', 'enable', need_lock=False)
+
+    def test_write_host_maintenance_enabled_uses_current_host(self, zk):
+        """Test write_host_maintenance_enabled uses current hostname when None."""
+        zk.write = MagicMock(return_value=True)
+        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/my-host')
+        with patch('src.zk.helpers.get_hostname', return_value='my-host'):
+            zk.write_host_maintenance_enabled()
+            zk.get_host_maintenance_path.assert_called_once_with(None)
+
+    def test_write_host_maintenance_enabled_failure_returns_false(self, zk):
+        """Test write_host_maintenance_enabled returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
+        result = zk.write_host_maintenance_enabled('test-host')
+        assert result is False
+
+
+class TestZookeeperTimeline:
+    """Tests for timeline methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_timeline tests ===
+
+    def test_get_timeline_returns_int(self, zk):
+        """Test get_timeline returns integer timeline."""
+        zk.get = MagicMock(return_value=5)
+        result = zk.get_timeline()
+        assert result == 5
+        zk.get.assert_called_once_with('timeline', preproc=int)
+
+    def test_get_timeline_returns_none_when_not_set(self, zk):
+        """Test get_timeline returns None when timeline not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_timeline()
+        assert result is None
+
+    # === write_timeline tests ===
+
+    def test_write_timeline_calls_write(self, zk):
+        """Test write_timeline writes timeline value."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_timeline(7)
+        assert result is True
+        zk.write.assert_called_once_with('timeline', 7)
+
+    def test_write_timeline_failure_returns_false(self, zk):
+        """Test write_timeline returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_timeline(7)
+        assert result is False
+
+
+class TestZookeeperReplicsInfo:
+    """Tests for global replics_info methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_replics_info tests ===
+
+    def test_get_replics_info_returns_list(self, zk):
+        """Test get_replics_info returns parsed JSON list."""
+        expected = [{'host': 'replica1', 'lag': 100}]
+        zk.get = MagicMock(return_value=expected)
+        result = zk.get_replics_info()
+        assert result == expected
+        zk.get.assert_called_once_with('replics_info', preproc=json.loads)
+
+    def test_get_replics_info_returns_none(self, zk):
+        """Test get_replics_info returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_replics_info()
+        assert result is None
+
+    # === noexcept_get_replics_info tests ===
+
+    def test_noexcept_get_replics_info_returns_list(self, zk):
+        """Test noexcept_get_replics_info returns parsed JSON list."""
+        expected = [{'host': 'replica1', 'lag': 100}]
+        zk.noexcept_get = MagicMock(return_value=expected)
+        result = zk.noexcept_get_replics_info()
+        assert result == expected
+        zk.noexcept_get.assert_called_once_with('replics_info', preproc=json.loads)
+
+    def test_noexcept_get_replics_info_returns_none_on_error(self, zk):
+        """Test noexcept_get_replics_info returns None on error."""
+        zk.noexcept_get = MagicMock(return_value=None)
+        result = zk.noexcept_get_replics_info()
+        assert result is None
+
+    # === write_replics_info tests ===
+
+    def test_write_replics_info_serializes_json(self, zk):
+        """Test write_replics_info serializes data as JSON."""
+        zk.write = MagicMock(return_value=True)
+        replics_info = [{'host': 'replica1', 'lag': 100}]
+        result = zk.write_replics_info(replics_info)
+        assert result is True
+        zk.write.assert_called_once_with('replics_info', replics_info, preproc=json.dumps)
+
+    def test_write_replics_info_failure_returns_false(self, zk):
+        """Test write_replics_info returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_replics_info([])
+        assert result is False

--- a/tests/unit/test_zk_maintenance_timeline.py
+++ b/tests/unit/test_zk_maintenance_timeline.py
@@ -100,7 +100,7 @@ class TestZookeeperMaintenance:
     def test_write_host_maintenance_enabled_calls_write(self, zk):
         """Test write_host_maintenance_enabled writes 'enable'."""
         zk.write = MagicMock(return_value=True)
-        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
+        zk._get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
         result = zk.write_host_maintenance_enabled('test-host')
         assert result is True
         zk.write.assert_called_once_with('maintenance/test-host', 'enable', need_lock=False)
@@ -108,15 +108,15 @@ class TestZookeeperMaintenance:
     def test_write_host_maintenance_enabled_uses_current_host(self, zk):
         """Test write_host_maintenance_enabled uses current hostname when None."""
         zk.write = MagicMock(return_value=True)
-        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/my-host')
+        zk._get_host_maintenance_path = MagicMock(return_value='maintenance/my-host')
         with patch('src.zk.helpers.get_hostname', return_value='my-host'):
             zk.write_host_maintenance_enabled()
-            zk.get_host_maintenance_path.assert_called_once_with(None)
+            zk._get_host_maintenance_path.assert_called_once_with(None)
 
     def test_write_host_maintenance_enabled_failure_returns_false(self, zk):
         """Test write_host_maintenance_enabled returns False on exception."""
         zk.write = MagicMock(side_effect=Exception('ZK error'))
-        zk.get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
+        zk._get_host_maintenance_path = MagicMock(return_value='maintenance/test-host')
         result = zk.write_host_maintenance_enabled('test-host')
         assert result is False
 

--- a/tests/unit/test_zk_maintenance_timeline.py
+++ b/tests/unit/test_zk_maintenance_timeline.py
@@ -32,14 +32,14 @@ class TestZookeeperMaintenance:
 
     def test_delete_maintenance_success(self, zk):
         """Test delete_maintenance calls delete with recursive=True."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         result = zk.delete_maintenance()
         assert result is True
         zk.delete.assert_called_once_with('maintenance', recursive=True)
 
     def test_delete_maintenance_failure_returns_false(self, zk):
-        """Test delete_maintenance returns False on exception."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        """Test delete_maintenance returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_maintenance()
         assert result is False
 

--- a/tests/unit/test_zk_maintenance_timeline.py
+++ b/tests/unit/test_zk_maintenance_timeline.py
@@ -157,6 +157,12 @@ class TestZookeeperTimeline:
         result = zk.write_timeline(7)
         assert result is False
 
+    def test_write_timeline_no_lock_returns_false(self, zk):
+        """Test write_timeline returns False when write() returns False (no lock holder)."""
+        zk.write = MagicMock(return_value=False)
+        result = zk.write_timeline(7)
+        assert result is False
+
 
 class TestZookeeperReplicsInfo:
     """Tests for global replics_info methods in Zookeeper class.

--- a/tests/unit/test_zk_maintenance_timeline.py
+++ b/tests/unit/test_zk_maintenance_timeline.py
@@ -4,28 +4,14 @@ Unit tests for Zookeeper maintenance, timeline and replics_info business methods
 """
 
 import json
-import time
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 class TestZookeeperMaintenance:
-    """Tests for maintenance methods in Zookeeper class."""
+    """Tests for maintenance methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_maintenance_status tests ===
 
@@ -136,21 +122,10 @@ class TestZookeeperMaintenance:
 
 
 class TestZookeeperTimeline:
-    """Tests for timeline methods in Zookeeper class."""
+    """Tests for timeline methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_timeline tests ===
 
@@ -184,21 +159,10 @@ class TestZookeeperTimeline:
 
 
 class TestZookeeperReplicsInfo:
-    """Tests for global replics_info methods in Zookeeper class."""
+    """Tests for global replics_info methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_replics_info tests ===
 

--- a/tests/unit/test_zk_members.py
+++ b/tests/unit/test_zk_members.py
@@ -1,0 +1,69 @@
+# encoding: utf-8
+"""
+Tests for get_members() / get_children() semantics contract.
+
+Contract:
+  - None   → ZK error (must NOT be interpreted as "empty cluster")
+  - []     → node absent or has no children (empty, but not an error)
+  - [...]  → normal non-empty list
+
+This distinction is critical for slot/quorum logic: treating a ZK error as an
+empty member list could silently destroy replication topology.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestGetMembersSemantics:
+    """Verify that get_members() correctly distinguishes error from empty."""
+
+    def test_get_members_returns_list_on_success(self, zk):
+        """get_members() returns the member list when ZK responds normally."""
+        zk.get_children = MagicMock(return_value=['host1', 'host2'])
+        result = zk.get_members()
+        assert result == ['host1', 'host2']
+
+    def test_get_members_returns_empty_list_when_node_absent(self, zk):
+        """get_members() returns [] when the members node has no children (or is absent)."""
+        zk.get_children = MagicMock(return_value=[])
+        result = zk.get_members()
+        assert result == []
+
+    def test_get_members_returns_none_on_zk_error(self, zk):
+        """get_members() returns None on ZK error (catch_except=True).
+
+        Callers MUST check ``is None`` before using the result — returning None
+        is fundamentally different from returning [] and must not be treated as
+        "empty cluster".
+        """
+        zk.get_children = MagicMock(return_value=None)
+        result = zk.get_members()
+        assert result is None
+
+    def test_get_members_none_is_not_empty_list(self, zk):
+        """None (error) and [] (empty) must be distinguishable, not equal."""
+        zk.get_children = MagicMock(return_value=None)
+        result_error = zk.get_members()
+
+        zk.get_children = MagicMock(return_value=[])
+        result_empty = zk.get_members()
+
+        assert result_error is None
+        assert result_empty == []
+        assert result_error != result_empty
+
+    def test_get_members_raises_on_zk_error_when_catch_except_false(self, zk):
+        """get_members(catch_except=False) re-raises ZookeeperException on error."""
+        from src.zk import ZookeeperException
+
+        zk.get_children = MagicMock(side_effect=ZookeeperException('zk error'))
+        with pytest.raises(ZookeeperException):
+            zk.get_members(catch_except=False)
+
+    def test_get_members_delegates_to_get_children_with_members_path(self, zk):
+        """get_members() queries the correct ZK path (MEMBERS_PATH)."""
+        zk.get_children = MagicMock(return_value=[])
+        zk.get_members()
+        zk.get_children.assert_called_once_with(zk.MEMBERS_PATH, catch_except=True)

--- a/tests/unit/test_zk_reconnect.py
+++ b/tests/unit/test_zk_reconnect.py
@@ -1,0 +1,52 @@
+# encoding: utf-8
+"""Tests for Zookeeper.reconnect lock-restoration contract."""
+
+from unittest.mock import MagicMock
+
+
+class TestReconnectLocks:
+    """After reconnect only PRIMARY_LOCK_PATH is restored; other locks are dropped."""
+
+    def test_reconnect_restores_only_primary_lock(self, zk):
+        from src.zk import Zookeeper
+
+        # Seed several held locks besides the primary one.
+        zk._locks = {
+            Zookeeper.PRIMARY_LOCK_PATH: MagicMock(),
+            Zookeeper.SWITCHOVER_LOCK_PATH: MagicMock(),
+            zk.get_host_alive_lock_path('host1'): MagicMock(),
+        }
+        zk._zk_client.reconnect = MagicMock(return_value=True)
+
+        assert zk.reconnect() is True
+
+        # Only the primary lock is re-initialized; non-primary locks are gone.
+        assert list(zk._locks.keys()) == [Zookeeper.PRIMARY_LOCK_PATH]
+
+    def test_reconnect_releases_old_locks(self, zk):
+        from src.zk import Zookeeper
+
+        primary = MagicMock()
+        side = MagicMock()
+        zk._locks = {
+            Zookeeper.PRIMARY_LOCK_PATH: primary,
+            Zookeeper.SWITCHOVER_LOCK_PATH: side,
+        }
+        zk._zk_client.reconnect = MagicMock(return_value=True)
+
+        zk.reconnect()
+
+        primary.release.assert_called_once()
+        side.release.assert_called_once()
+
+    def test_reconnect_drops_all_locks_on_failure(self, zk):
+        from src.zk import Zookeeper
+
+        zk._locks = {
+            Zookeeper.PRIMARY_LOCK_PATH: MagicMock(),
+            Zookeeper.SWITCHOVER_LOCK_PATH: MagicMock(),
+        }
+        zk._zk_client.reconnect = MagicMock(return_value=False)
+
+        assert zk.reconnect() is False
+        assert zk._locks == {}

--- a/tests/unit/test_zk_session_expired.py
+++ b/tests/unit/test_zk_session_expired.py
@@ -1,0 +1,56 @@
+# encoding: utf-8
+"""
+Zookeeper-level tests for SessionExpiredError handling.
+
+Tests that Zookeeper.get/write/noexcept_get/noexcept_write wrap
+ZkSessionExpiredError into ZookeeperException, and that is_alive()
+delegates correctly when the ZkClient reports a dead session.
+
+ZkClient-level session-expired behaviour is covered separately in
+test_zk_client.py (TestZkClientState, TestListener, TestZkClientGet/Write).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.zk import ZookeeperException
+from src.zk_client import ZkSessionExpiredError
+
+
+class TestZookeeperGetSessionExpired:
+    """Zookeeper.get() / noexcept_get() on ZkSessionExpiredError."""
+
+    def test_get_raises_zookeeper_exception(self, zk):
+        zk._zk_client.get = MagicMock(side_effect=ZkSessionExpiredError())
+        with pytest.raises(ZookeeperException):
+            zk.get('test_key')
+
+    def test_noexcept_get_returns_none(self, zk):
+        zk._zk_client.get = MagicMock(side_effect=ZkSessionExpiredError())
+        assert zk.noexcept_get('test_key') is None
+
+
+class TestZookeeperWriteSessionExpired:
+    """Zookeeper.write() / noexcept_write() on ZkSessionExpiredError."""
+
+    def test_write_raises_zookeeper_exception(self, zk):
+        zk._zk_client.write = MagicMock(side_effect=ZkSessionExpiredError())
+        with pytest.raises(ZookeeperException):
+            zk.write('test_key', 'val', need_lock=False)
+
+    def test_noexcept_write_returns_false(self, zk):
+        zk._zk_client.write = MagicMock(side_effect=ZkSessionExpiredError())
+        assert zk.noexcept_write('test_key', 'val', need_lock=False) is False
+
+
+class TestZookeeperIsAliveSessionExpired:
+    """Zookeeper.is_alive() delegates to ZkClient.is_alive()."""
+
+    def test_is_alive_false_when_client_session_expired(self, zk):
+        zk._zk_client.is_alive = MagicMock(return_value=False)
+        assert zk.is_alive() is False
+
+    def test_is_alive_true_when_client_connected(self, zk):
+        zk._zk_client.is_alive = MagicMock(return_value=True)
+        assert zk.is_alive() is True

--- a/tests/unit/test_zk_state.py
+++ b/tests/unit/test_zk_state.py
@@ -1,0 +1,55 @@
+# encoding: utf-8
+"""Tests for Zookeeper.get_state and _get_ssn_info robustness."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestGetSsnInfo:
+    """_get_ssn_info must not crash when MEMBERS_PATH is absent."""
+
+    def test_returns_empty_dict_when_all_hosts_none(self, zk):
+        """get_children returns None (node absent) → empty dict, no TypeError."""
+        zk.get_children = MagicMock(return_value=None)
+        result = zk._get_ssn_info()
+        assert result == {}
+
+    def test_returns_empty_dict_when_all_hosts_empty(self, zk):
+        zk.get_children = MagicMock(return_value=[])
+        result = zk._get_ssn_info()
+        assert result == {}
+
+    def test_returns_ssn_info_for_hosts(self, zk):
+        zk.get_children = MagicMock(return_value=['host1', 'host2'])
+        zk.get = MagicMock(return_value='some_value')
+        result = zk._get_ssn_info()
+        assert 'host1' in result
+        assert 'host2' in result
+
+
+class TestGetState:
+    """get_state must not crash when MEMBERS_PATH is absent."""
+
+    def _make_alive_zk(self, zk):
+        """Wire zk so that is_alive returns True and basic gets return None."""
+        zk.is_alive = MagicMock(return_value=True)
+        zk.get = MagicMock(return_value=None)
+        zk.exists_path = MagicMock(return_value=False)
+        zk.get_current_lock_version = MagicMock(return_value=None)
+        zk.get_current_lock_holder = MagicMock(return_value=None)
+        zk._get_ssn_info = MagicMock(return_value={})
+        return zk
+
+    def test_get_state_does_not_crash_when_members_path_absent(self, zk):
+        """Ensure get_state survives when _get_ssn_info returns {} (MEMBERS_PATH absent)."""
+        self._make_alive_zk(zk)
+        # Should not raise TypeError
+        data = zk.get_state()
+        assert 'alive' in data
+        assert data['synchronous_standby_names'] == {}
+
+    def test_get_state_raises_when_not_alive(self, zk):
+        from src.zk import ZookeeperException
+        zk.is_alive = MagicMock(return_value=False)
+        with pytest.raises(ZookeeperException):
+            zk.get_state()

--- a/tests/unit/test_zk_state.py
+++ b/tests/unit/test_zk_state.py
@@ -2,7 +2,7 @@
 """Tests for Zookeeper.get_state and _get_ssn_info robustness."""
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 class TestGetSsnInfo:
@@ -35,7 +35,6 @@ class TestGetState:
         zk.is_alive = MagicMock(return_value=True)
         zk.get = MagicMock(return_value=None)
         zk.exists_path = MagicMock(return_value=False)
-        zk.get_current_lock_version = MagicMock(return_value=None)
         zk.get_current_lock_holder = MagicMock(return_value=None)
         zk._get_ssn_info = MagicMock(return_value={})
         return zk

--- a/tests/unit/test_zk_state.py
+++ b/tests/unit/test_zk_state.py
@@ -40,14 +40,6 @@ class TestGetState:
         zk._get_ssn_info = MagicMock(return_value={})
         return zk
 
-    def test_get_state_does_not_crash_when_members_path_absent(self, zk):
-        """Ensure get_state survives when _get_ssn_info returns {} (MEMBERS_PATH absent)."""
-        self._make_alive_zk(zk)
-        # Should not raise TypeError
-        data = zk.get_state()
-        assert 'alive' in data
-        assert data['synchronous_standby_names'] == {}
-
     def test_get_state_raises_when_not_alive(self, zk):
         from src.zk import ZookeeperException
         zk.is_alive = MagicMock(return_value=False)

--- a/tests/unit/test_zk_switchover_timing.py
+++ b/tests/unit/test_zk_switchover_timing.py
@@ -80,15 +80,6 @@ class TestZookeeperSwitchover:
         result = zk.write_switchover_candidate('candidate-host')
         assert result is False
 
-    # === get_switchover_candidate_host tests ===
-
-    def test_get_switchover_candidate_host_returns_value(self, zk):
-        """Test get_switchover_candidate_host returns hostname."""
-        zk.get = MagicMock(return_value='candidate-host')
-        result = zk.get_switchover_candidate_host()
-        assert result == 'candidate-host'
-        zk.get.assert_called_once_with('switchover/candidate')
-
     # === write_switchover_side_replicas tests ===
 
     def test_write_switchover_side_replicas_serializes_json(self, zk):

--- a/tests/unit/test_zk_switchover_timing.py
+++ b/tests/unit/test_zk_switchover_timing.py
@@ -127,7 +127,7 @@ class TestZookeeperSwitchover:
 
     def test_cleanup_switchover_deletes_all_paths(self, zk):
         """Test cleanup_switchover deletes all 5 switchover paths."""
-        zk.delete = MagicMock()
+        zk.delete = MagicMock(return_value=True)
         zk.cleanup_switchover()
         assert zk.delete.call_count == 5
         deleted_paths = [call[0][0] for call in zk.delete.call_args_list]
@@ -137,9 +137,9 @@ class TestZookeeperSwitchover:
         assert 'switchover/master' in deleted_paths
         assert 'failover_state' in deleted_paths
 
-    def test_cleanup_switchover_continues_on_error(self, zk):
+    def test_cleanup_switchover_continues_on_failure(self, zk):
         """Test cleanup_switchover continues even if one delete fails."""
-        zk.delete = MagicMock(side_effect=[Exception('ZK error'), None, None, None, None])
+        zk.delete = MagicMock(side_effect=[False, True, True, True, True])
         # Should not raise exception
         zk.cleanup_switchover()
         assert zk.delete.call_count == 5
@@ -192,7 +192,7 @@ class TestZookeeperTiming:
         zk.delete.assert_called_once_with('timing/failover', recursive=True)
 
     def test_delete_timing_failure_returns_false(self, zk):
-        """Test delete_timing returns False on exception."""
-        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        """Test delete_timing returns False when delete fails."""
+        zk.delete = MagicMock(return_value=False)
         result = zk.delete_timing('failover')
         assert result is False

--- a/tests/unit/test_zk_switchover_timing.py
+++ b/tests/unit/test_zk_switchover_timing.py
@@ -6,25 +6,12 @@ Unit tests for Zookeeper switchover and timing business methods.
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestZookeeperSwitchover:
-    """Tests for switchover methods in Zookeeper class."""
+    """Tests for switchover methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_switchover_state tests ===
 
@@ -159,21 +146,10 @@ class TestZookeeperSwitchover:
 
 
 class TestZookeeperTiming:
-    """Tests for timing methods in Zookeeper class."""
+    """Tests for timing methods in Zookeeper class.
 
-    @pytest.fixture
-    def zk(self):
-        """Create a Zookeeper instance with mocked dependencies."""
-        with patch('src.zk.KazooClient'), \
-             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
-            from src.zk import Zookeeper
-            config = MagicMock()
-            config.getint.return_value = 10
-            config.getfloat.return_value = 5.0
-            config.getboolean.return_value = False
-            config.get.return_value = '/pgconsul/'
-            zk = Zookeeper(config, plugins=MagicMock())
-            return zk
+    The ``zk`` fixture is provided by ``tests/unit/conftest.py``.
+    """
 
     # === get_timing tests ===
 

--- a/tests/unit/test_zk_switchover_timing.py
+++ b/tests/unit/test_zk_switchover_timing.py
@@ -80,6 +80,12 @@ class TestZookeeperSwitchover:
         result = zk.write_switchover_candidate('candidate-host')
         assert result is False
 
+    def test_write_switchover_candidate_no_lock_returns_false(self, zk):
+        """Test write_switchover_candidate returns False when write() returns False (no lock holder)."""
+        zk.write = MagicMock(return_value=False)
+        result = zk.write_switchover_candidate('candidate-host')
+        assert result is False
+
     # === write_switchover_side_replicas tests ===
 
     def test_write_switchover_side_replicas_serializes_json(self, zk):

--- a/tests/unit/test_zk_switchover_timing.py
+++ b/tests/unit/test_zk_switchover_timing.py
@@ -1,0 +1,222 @@
+# encoding: utf-8
+"""
+Unit tests for Zookeeper switchover and timing business methods.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestZookeeperSwitchover:
+    """Tests for switchover methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_switchover_state tests ===
+
+    def test_get_switchover_state_returns_value(self, zk):
+        """Test get_switchover_state returns value from get."""
+        zk.get = MagicMock(return_value='initiated')
+        result = zk.get_switchover_state()
+        assert result == 'initiated'
+        zk.get.assert_called_once_with('switchover/state')
+
+    def test_get_switchover_state_returns_none(self, zk):
+        """Test get_switchover_state returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_switchover_state()
+        assert result is None
+
+    # === write_switchover_state tests ===
+
+    def test_write_switchover_state_calls_write(self, zk):
+        """Test write_switchover_state writes state with need_lock=False."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_switchover_state('initiated')
+        assert result is True
+        zk.write.assert_called_once_with('switchover/state', 'initiated', need_lock=False)
+
+    def test_write_switchover_state_with_candidate_found(self, zk):
+        """Test write_switchover_state with 'candidate_found' state."""
+        zk.write = MagicMock(return_value=True)
+        zk.write_switchover_state('candidate_found')
+        zk.write.assert_called_once_with('switchover/state', 'candidate_found', need_lock=False)
+
+    def test_write_switchover_state_failure_returns_false(self, zk):
+        """Test write_switchover_state returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_switchover_state('initiated')
+        assert result is False
+
+    # === get_switchover_primary_info tests ===
+
+    def test_get_switchover_primary_info_parses_json(self, zk):
+        """Test get_switchover_primary_info returns parsed JSON."""
+        expected = {'fqdn': 'primary.example.com', 'timeline': 5}
+        zk.get = MagicMock(return_value=expected)
+        result = zk.get_switchover_primary_info()
+        assert result == expected
+        zk.get.assert_called_once_with('switchover/master', preproc=json.loads)
+
+    def test_get_switchover_primary_info_returns_none(self, zk):
+        """Test get_switchover_primary_info returns None when not set."""
+        zk.get = MagicMock(return_value=None)
+        result = zk.get_switchover_primary_info()
+        assert result is None
+
+    # === write_switchover_candidate tests ===
+
+    def test_write_switchover_candidate_calls_write(self, zk):
+        """Test write_switchover_candidate writes candidate hostname."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_switchover_candidate('candidate-host')
+        assert result is True
+        zk.write.assert_called_once_with('switchover/candidate', 'candidate-host')
+
+    def test_write_switchover_candidate_failure_returns_false(self, zk):
+        """Test write_switchover_candidate returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_switchover_candidate('candidate-host')
+        assert result is False
+
+    # === get_switchover_candidate_host tests ===
+
+    def test_get_switchover_candidate_host_returns_value(self, zk):
+        """Test get_switchover_candidate_host returns hostname."""
+        zk.get = MagicMock(return_value='candidate-host')
+        result = zk.get_switchover_candidate_host()
+        assert result == 'candidate-host'
+        zk.get.assert_called_once_with('switchover/candidate')
+
+    # === write_switchover_side_replicas tests ===
+
+    def test_write_switchover_side_replicas_serializes_json(self, zk):
+        """Test write_switchover_side_replicas serializes list as JSON."""
+        zk.write = MagicMock(return_value=True)
+        replicas = ['replica1', 'replica2']
+        result = zk.write_switchover_side_replicas(replicas)
+        assert result is True
+        zk.write.assert_called_once_with('switchover/side_replicas', replicas, preproc=json.dumps)
+
+    def test_write_switchover_side_replicas_failure_returns_false(self, zk):
+        """Test write_switchover_side_replicas returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_switchover_side_replicas([])
+        assert result is False
+
+    # === write_last_switchover_time tests ===
+
+    def test_write_last_switchover_time_calls_write(self, zk):
+        """Test write_last_switchover_time writes current time."""
+        zk.write = MagicMock(return_value=True)
+        result = zk.write_last_switchover_time()
+        assert result is True
+        call_args = zk.write.call_args
+        assert call_args[0][0] == 'last_switchover_time'
+        assert isinstance(call_args[0][1], float)
+        assert call_args[1]['need_lock'] is False
+
+    def test_write_last_switchover_time_failure_returns_false(self, zk):
+        """Test write_last_switchover_time returns False on exception."""
+        zk.write = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.write_last_switchover_time()
+        assert result is False
+
+    # === cleanup_switchover tests ===
+
+    def test_cleanup_switchover_deletes_all_paths(self, zk):
+        """Test cleanup_switchover deletes all 5 switchover paths."""
+        zk.delete = MagicMock()
+        zk.cleanup_switchover()
+        assert zk.delete.call_count == 5
+        deleted_paths = [call[0][0] for call in zk.delete.call_args_list]
+        assert 'switchover/candidate' in deleted_paths
+        assert 'switchover/side_replicas' in deleted_paths
+        assert 'switchover/state' in deleted_paths
+        assert 'switchover/master' in deleted_paths
+        assert 'failover_state' in deleted_paths
+
+    def test_cleanup_switchover_continues_on_error(self, zk):
+        """Test cleanup_switchover continues even if one delete fails."""
+        zk.delete = MagicMock(side_effect=[Exception('ZK error'), None, None, None, None])
+        # Should not raise exception
+        zk.cleanup_switchover()
+        assert zk.delete.call_count == 5
+
+
+class TestZookeeperTiming:
+    """Tests for timing methods in Zookeeper class."""
+
+    @pytest.fixture
+    def zk(self):
+        """Create a Zookeeper instance with mocked dependencies."""
+        with patch('src.zk.KazooClient'), \
+             patch('src.zk.helpers.get_lockpath_prefix', return_value='/pgconsul/'):
+            from src.zk import Zookeeper
+            config = MagicMock()
+            config.getint.return_value = 10
+            config.getfloat.return_value = 5.0
+            config.getboolean.return_value = False
+            config.get.return_value = '/pgconsul/'
+            zk = Zookeeper(config, plugins=MagicMock())
+            return zk
+
+    # === get_timing tests ===
+
+    def test_get_timing_returns_float(self, zk):
+        """Test get_timing returns float timestamp."""
+        zk.noexcept_get = MagicMock(return_value=1234.5)
+        result = zk.get_timing('failover')
+        assert result == 1234.5
+        zk.noexcept_get.assert_called_once_with('timing/failover', preproc=float)
+
+    def test_get_timing_returns_none_on_error(self, zk):
+        """Test get_timing returns None on error."""
+        zk.noexcept_get = MagicMock(return_value=None)
+        result = zk.get_timing('failover')
+        assert result is None
+
+    # === write_timing tests ===
+
+    def test_write_timing_calls_ensure_path_and_noexcept_write(self, zk):
+        """Test write_timing calls ensure_path before noexcept_write."""
+        zk.ensure_path = MagicMock(return_value=True)
+        zk.noexcept_write = MagicMock(return_value=True)
+        zk.write_timing('failover', 1234.5)
+        zk.ensure_path.assert_called_once_with('timing/failover')
+        zk.noexcept_write.assert_called_once_with('timing/failover', 1234.5, need_lock=False)
+
+    def test_write_timing_does_not_raise_on_error(self, zk):
+        """Test write_timing does not raise exception on error."""
+        zk.ensure_path = MagicMock(side_effect=Exception('ZK error'))
+        # Should not raise
+        zk.write_timing('failover', 1234.5)
+
+    # === delete_timing tests ===
+
+    def test_delete_timing_calls_delete(self, zk):
+        """Test delete_timing calls delete with recursive=True."""
+        zk.delete = MagicMock(return_value=True)
+        result = zk.delete_timing('failover')
+        assert result is True
+        zk.delete.assert_called_once_with('timing/failover', recursive=True)
+
+    def test_delete_timing_failure_returns_false(self, zk):
+        """Test delete_timing returns False on exception."""
+        zk.delete = MagicMock(side_effect=Exception('ZK error'))
+        result = zk.delete_timing('failover')
+        assert result is False


### PR DESCRIPTION
Separate low-level KazooClient handling (connection lifecycle,
reconnect with backoff, domain exceptions, LockHandle) into ZkClient
and turn Zookeeper into a typed facade with semantic methods for every
ZK path operation. Update all call sites and add unit tests.