### PR TITLE
fix: stop dead_iter infinite loop on stale postmaster.pid

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1000,7 +1000,7 @@ class pgconsul(object):
             return None
 
         self.db.pgpooler('stop')
-        if not is_in_terminal_state or self.db.get_postgresql_status() == 0:
+        if not is_in_terminal_state:
             logging.warning('Waiting for PostgreSQL to finish starting or stopping.')
             return None
 

--- a/src/pg.py
+++ b/src/pg.py
@@ -288,7 +288,9 @@ class Postgres(object):
 
     def is_alive_and_in_terminal_state(self):
         """
-        Check that postgresql is alive
+        Check that postgresql is alive.
+        Returns (is_alive, is_terminal_state) where is_terminal_state=False means
+        PostgreSQL is starting up or shutting down (non-terminal / transient state).
         """
         try:
             # In order to check that postgresql is really alive
@@ -298,7 +300,7 @@ class Postgres(object):
             return len(res) > 0, True
         except Exception:
             logging.debug('Error checking alive/running state', exc_info=True)
-            return False, True
+            return False, self.terminal_state
 
     def get_role(self):
         """


### PR DESCRIPTION
pg_ctl status uses only kill(pid, 0) which gives false positive
when postmaster.pid is not cleaned up after SIGKILL and the PID
is reused by another process (e.g. after container restart).

Root cause: is_alive_and_in_terminal_state() always returned
terminal_state=True, ignoring self.terminal_state set by
reconnect() on TRANSIENT_ERRORS (starting up / shutting down).

Fix:
- is_alive_and_in_terminal_state() now returns self.terminal_state
  instead of hardcoded True in the exception branch
- dead_iter() no longer calls get_postgresql_status() as a
  workaround; the first condition is now sufficient
