### PR TITLE
MDB-48301: Wait for walreceiver stop before failover election (stable branch)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -106,6 +106,9 @@ def read_config(filename=None, options=None):
             'primary_switch_restart': 'yes',
             'primary_switch_disable_archive_restore': 'yes',
             'close_detached_after': 300,
+            # How long to wait for walreceiver to actually stop after emptying primary_conninfo + reload.
+            # Startup applies SIGHUP asynchronously; if it does not stop the receiver in time, abort failover.
+            'walreceiver_disable_timeout': 5,
         },
         'commands': {
             'promote': '/usr/lib/postgresql/10/bin/pg_ctl promote -D %p',
@@ -124,7 +127,7 @@ def read_config(filename=None, options=None):
         },
         'debug': {
             'election_loser_timeout': 0,  # Timeout for election losers. For test purposes only.
-            'pre_pause_sleep': 0,  # Sleep before pg_wal_replay_pause() in _can_do_failover. For test purposes only.
+            'pre_pause_sleep': 0,  # Sleep before disabling walreceiver in _can_do_failover. For test purposes only.
             'election_lsn_read_sleep': 0,  # Sleep right after reading wal_receive_lsn for the election vote. For test purposes only.
         },
         'plugins': {'wals_to_upload': 20},

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -124,6 +124,8 @@ def read_config(filename=None, options=None):
         },
         'debug': {
             'election_loser_timeout': 0,  # Timeout for election losers. For test purposes only.
+            'pre_pause_sleep': 0,  # Sleep before pg_wal_replay_pause() in _can_do_failover. For test purposes only.
+            'election_lsn_read_sleep': 0,  # Sleep right after reading wal_receive_lsn for the election vote. For test purposes only.
         },
         'plugins': {'wals_to_upload': 20},
     }

--- a/src/main.py
+++ b/src/main.py
@@ -1655,10 +1655,11 @@ class pgconsul(object):
 
         pre_pause_sleep = self.config.getfloat('debug', 'pre_pause_sleep', fallback=0)
         if pre_pause_sleep:
-            logging.debug('Sleep for test purposes before pg_wal_replay_pause: %s', pre_pause_sleep)
+            logging.debug('Sleep for test purposes before disabling walreceiver: %s', pre_pause_sleep)
             time.sleep(pre_pause_sleep)
 
-        if not self.db.pg_wal_replay_pause():
+        disable_timeout = self.config.getfloat('replica', 'walreceiver_disable_timeout')
+        if not self.db.disable_wal_receiver(disable_timeout):
             return False
 
         return self._make_election(replica_infos, allow_data_loss)

--- a/src/main.py
+++ b/src/main.py
@@ -1653,6 +1653,11 @@ class pgconsul(object):
             logging.warning('Promote is not allowed with given configuration.')
             return False
 
+        pre_pause_sleep = self.config.getfloat('debug', 'pre_pause_sleep', fallback=0)
+        if pre_pause_sleep:
+            logging.debug('Sleep for test purposes before pg_wal_replay_pause: %s', pre_pause_sleep)
+            time.sleep(pre_pause_sleep)
+
         if not self.db.pg_wal_replay_pause():
             return False
 
@@ -1661,6 +1666,13 @@ class pgconsul(object):
     def _make_election(self, replica_infos: ReplicaInfos, allow_data_loss: bool) -> bool:
         election_timeout = self.config.getint('global', 'election_timeout')
         quorum_size = len(helpers.make_current_replics_quorum(replica_infos, self.zk.get_alive_hosts(all_hosts_timeout=election_timeout / 3)))
+        host_lsn = self.db.get_wal_receive_lsn() or '0'
+
+        election_lsn_read_sleep = self.config.getfloat('debug', 'election_lsn_read_sleep', fallback=0)
+        if election_lsn_read_sleep:
+            logging.debug('Read lsn for election vote: %s. Sleep for test purposes: %s', host_lsn, election_lsn_read_sleep)
+            time.sleep(election_lsn_read_sleep)
+
         election = FailoverElection(
             self.zk,
             election_timeout,
@@ -1668,7 +1680,7 @@ class pgconsul(object):
             self._replication_manager,
             allow_data_loss,
             self.config.getint('global', 'priority'),
-            self.db.get_wal_receive_lsn() or '0',
+            host_lsn,
             quorum_size,
         )
         try:

--- a/src/pg.py
+++ b/src/pg.py
@@ -808,22 +808,6 @@ class Postgres(object):
         replay_diff = self.get_replay_diff()
         return prev_replay_diff < replay_diff
 
-    def pg_wal_replay_pause(self) -> bool:
-        try:
-            self._disable_wal_receiver()
-            if not self.is_wal_replay_paused():
-                self._pg_wal_replay("pause")
-        except psycopg2.errors.ObjectNotInPrerequisiteState as exc:
-            # pg_wal_replay_pause() cannot be executed after promotion is triggered
-            # so we just leave iteration
-            logging.error('Could not replay pause. %s', str(exc))
-            return False
-        except Exception as exc:
-            logging.error('Could not replay pause. Unexpected error.')
-            logging.exception(exc)
-            return False
-        return True
-
     def pg_wal_replay_resume(self):
         if self.is_wal_replay_paused():
             logging.debug('WAL replay is paused. So we resume it')
@@ -836,21 +820,49 @@ class Postgres(object):
         self.enable_wal_receiver_if_disabled()
         self.pg_wal_replay_resume()
 
-    def _disable_wal_receiver(self):
+    def _is_wal_receiver_stopped(self) -> bool:
         """
-        Disable walreceiver
+        True if pg_stat_wal_receiver has no rows (receiver process is gone).
+        Raises on query errors so callers do not treat DB failures as "stopped".
+        """
+        cur = self._exec_query('SELECT pid FROM pg_stat_wal_receiver')
+        return not cur.fetchall()
+
+    def disable_wal_receiver(self, timeout: float) -> bool:
+        """
+        Disable walreceiver by clearing primary_conninfo, reloading, and waiting
+        until the receiver process actually disappears.
+
+        Connects to Postgres on port 5432, not through the pooler. pgconsul
+        cannot rely on the pooler's state in the general case; durability
+        guarantees must rest on PostgreSQL itself.
+
+        Startup applies the reload asynchronously, so emptying primary_conninfo
+        alone does not guarantee that WAL is no longer being received/acked.
         """
         try:
-            if self._exec_query('SHOW primary_conninfo;').fetchone()[0] == '':
-                logging.debug('walreceiver is already disabled')
+            if self._exec_query('SHOW primary_conninfo;').fetchone()[0] != '':
+                logging.info('ACTION. Disabling walreceiver.')
+                self._alter_system_set_param('primary_conninfo', '')
+                if not self.reload():
+                    logging.error('Could not reload PostgreSQL after disabling walreceiver.')
+                    return False
+            else:
+                logging.debug('primary_conninfo is already empty')
 
-            logging.info('ACTION. Disabling walreceiver.')
-
-            self._alter_system_set_param('primary_conninfo', '')
-            self.reload()
+            if not helpers.await_for(
+                self._is_wal_receiver_stopped,
+                timeout,
+                'walreceiver to stop',
+            ):
+                logging.error('Walreceiver did not stop within %.1fs after disable.', timeout)
+                return False
+            logging.info('Walreceiver stopped.')
+            return True
         except Exception as exc:
             logging.error('Could not disable walreceiver. Unexpected error.')
             logging.exception(exc)
+            return False
 
     def enable_wal_receiver_if_disabled(self):
         """

--- a/src/pg.py
+++ b/src/pg.py
@@ -810,7 +810,8 @@ class Postgres(object):
 
     def pg_wal_replay_pause(self) -> bool:
         try:
-            if self._disable_wal_receiver():
+            self._disable_wal_receiver()
+            if not self.is_wal_replay_paused():
                 self._pg_wal_replay("pause")
         except psycopg2.errors.ObjectNotInPrerequisiteState as exc:
             # pg_wal_replay_pause() cannot be executed after promotion is triggered

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/ap
         postgresql-client-common
 RUN echo "wal_level = replica" >> /etc/postgresql-common/createcluster.conf
 
-RUN apt-get -y install \
+RUN apt-get update && apt-get -y install \
         git \
         pgbouncer \
         postgresql-$PG_MAJOR \

--- a/tests/features/failover_with_network_inconsistency.feature
+++ b/tests/features/failover_with_network_inconsistency.feature
@@ -75,3 +75,89 @@ Feature: Failover with network inconsistency
         """
         Then container "postgresql1" is a replica of container "postgresql2" and streaming
         Then container "postgresql3" is a replica of container "postgresql2" and streaming
+
+    @failover
+    Scenario: Old primary can not get a write acknowledged after voting for a new primary has started
+        # Regression test for a race between disabling walreceiver (which is only
+        # actually enacted by the replica's startup process, asynchronously) and
+        # reading wal_receive_lsn for the failover election vote. We simulate the
+        # worst case of that race (startup frozen with SIGSTOP, so the disable
+        # never takes effect) combined with the old primary coming back mid-election,
+        # and check that it is still impossible to get a synchronous write
+        # acknowledged by the old primary once voting has begun.
+        Given a "pgconsul" container common config
+        """
+            pgconsul.conf:
+                global:
+                    priority: 0
+                    use_replication_slots: 'yes'
+                    max_rewind_retries: 3
+                    election_timeout: 30
+                    update_prio_in_zk: 'yes'
+                    autofailover: 'yes'
+                    quorum_commit: 'yes'
+                    use_lwaldump: 'yes'
+                primary:
+                    change_replication_type: 'yes'
+                    change_replication_metric: 'count'
+                    primary_switch_checks: 6
+                replica:
+                    allow_potential_data_loss: 'no'
+                    primary_unavailability_timeout: 2
+                    primary_switch_checks: 10
+                    min_failover_timeout: 1
+                    primary_switch_restart: 'no'
+                plugins:
+                    wals_to_upload: 100
+                debug:
+                    pre_pause_sleep: 60
+                    election_lsn_read_sleep: 10
+            postgresql.conf:
+                synchronous_commit: 'on'
+                wal_retrieve_retry_interval: '1s'
+        """
+          And a following cluster with "zookeeper" with replication slots
+        """
+            postgresql1:
+                role: primary
+            postgresql2:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 2
+            postgresql3:
+                role: replica
+                config:
+                    pgconsul.conf:
+                        global:
+                            priority: 1
+        """
+        When we wait "30" seconds
+        When we disable archiving in "postgresql1"
+        # Kill the old primary so replicas start failover
+        When we gracefully stop "pgconsul" in container "postgresql1"
+        When we gracefully stop "postgres" in container "postgresql1"
+        # Wait until both replicas have entered _can_do_failover and are sleeping
+        # right before pg_wal_replay_pause()
+        Then container "postgresql2" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
+        Then container "postgresql3" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
+        # Old primary comes back before either replica has disabled its walreceiver
+        When we start "postgres" in container "postgresql1"
+        Then container "postgresql2" walreceiver is streaming from container "postgresql1"
+        Then container "postgresql3" walreceiver is streaming from container "postgresql1"
+        # Freeze startup for a bounded window (auto-CONT after N seconds).
+        # On current code replicas vote while startup is still frozen and walreceiver
+        # stays alive, so the subsequent CREATE TABLE can be sync-acked (test fails).
+        # After a fix that waits for walreceiver to actually stop before reading LSN,
+        # replicas only vote after auto-CONT; by then walreceiver is gone and CREATE TABLE
+        # must time out (test passes).
+        # N must cover: remaining pre_pause_sleep + election_lsn_read_sleep + vote + CREATE TABLE.
+        When we freeze process "postgres: startup" in container "postgresql2" for "60" seconds
+        And we freeze process "postgres: startup" in container "postgresql3" for "60" seconds
+        # Wait until both replicas have captured their LSN and voted
+        Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql2_1.pgconsul_pgconsul_net/lsn"
+        Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql3_1.pgconsul_pgconsul_net/lsn"
+        # The old primary must not be able to get a synchronous write acknowledged
+        # by any replica once voting has started
+        When we create a table in container "postgresql1" with statement timeout "5000" ms and expect it does not complete

--- a/tests/features/failover_with_network_inconsistency.feature
+++ b/tests/features/failover_with_network_inconsistency.feature
@@ -140,14 +140,14 @@ Feature: Failover with network inconsistency
         When we gracefully stop "postgres" in container "postgresql1"
         # Wait until both replicas have entered _can_do_failover and are sleeping
         # right before disabling walreceiver
-        Then container "postgresql2" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
-        Then container "postgresql3" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
+        Then container "postgresql2" pgconsul log contains "Sleep for test purposes before disabling walreceiver"
+        Then container "postgresql3" pgconsul log contains "Sleep for test purposes before disabling walreceiver"
         # Old primary comes back before either replica has disabled its walreceiver
         When we start "postgres" in container "postgresql1"
         Then container "postgresql2" walreceiver is streaming from container "postgresql1"
         Then container "postgresql3" walreceiver is streaming from container "postgresql1"
         # Freeze startup for a bounded window (auto-CONT after N seconds).
-        # On current code replicas vote while startup is still frozen and walreceiver
+        # On code before pull/200 replicas vote while startup is still frozen and walreceiver
         # stays alive, so the subsequent CREATE TABLE can be sync-acked (test fails).
         # After a fix that waits for walreceiver to actually stop before reading LSN,
         # replicas only vote after auto-CONT; by then walreceiver is gone and CREATE TABLE

--- a/tests/features/failover_with_network_inconsistency.feature
+++ b/tests/features/failover_with_network_inconsistency.feature
@@ -153,8 +153,8 @@ Feature: Failover with network inconsistency
         # replicas only vote after auto-CONT; by then walreceiver is gone and CREATE TABLE
         # must time out (test passes).
         # N must cover: remaining pre_pause_sleep + election_lsn_read_sleep + vote + CREATE TABLE.
-        When we freeze process "postgres: startup" in container "postgresql2" for "70" seconds
-        And we freeze process "postgres: startup" in container "postgresql3" for "70" seconds
+        When we freeze process "postgres: startup" in container "postgresql2" for "60" seconds
+        And we freeze process "postgres: startup" in container "postgresql3" for "60" seconds
         # Wait until both replicas have captured their LSN and voted
         Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql2_1.pgconsul_pgconsul_net/lsn"
         Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql3_1.pgconsul_pgconsul_net/lsn"

--- a/tests/features/failover_with_network_inconsistency.feature
+++ b/tests/features/failover_with_network_inconsistency.feature
@@ -139,7 +139,7 @@ Feature: Failover with network inconsistency
         When we gracefully stop "pgconsul" in container "postgresql1"
         When we gracefully stop "postgres" in container "postgresql1"
         # Wait until both replicas have entered _can_do_failover and are sleeping
-        # right before pg_wal_replay_pause()
+        # right before disabling walreceiver
         Then container "postgresql2" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
         Then container "postgresql3" pgconsul log contains "Sleep for test purposes before pg_wal_replay_pause"
         # Old primary comes back before either replica has disabled its walreceiver
@@ -153,11 +153,11 @@ Feature: Failover with network inconsistency
         # replicas only vote after auto-CONT; by then walreceiver is gone and CREATE TABLE
         # must time out (test passes).
         # N must cover: remaining pre_pause_sleep + election_lsn_read_sleep + vote + CREATE TABLE.
-        When we freeze process "postgres: startup" in container "postgresql2" for "60" seconds
-        And we freeze process "postgres: startup" in container "postgresql3" for "60" seconds
+        When we freeze process "postgres: startup" in container "postgresql2" for "70" seconds
+        And we freeze process "postgres: startup" in container "postgresql3" for "70" seconds
         # Wait until both replicas have captured their LSN and voted
         Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql2_1.pgconsul_pgconsul_net/lsn"
         Then zookeeper "zookeeper1" has key "/pgconsul/postgresql/election_vote/pgconsul_postgresql3_1.pgconsul_pgconsul_net/lsn"
         # The old primary must not be able to get a synchronous write acknowledged
         # by any replica once voting has started
-        When we create a table in container "postgresql1" with statement timeout "5000" ms and expect it does not complete
+        When we create a table in container "postgresql1" and expect it does not complete within "5000" ms

--- a/tests/steps/cluster.py
+++ b/tests/steps/cluster.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import contextlib
 import copy
 import operator
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 import psycopg2
 import yaml
@@ -1365,36 +1367,48 @@ def step_freeze_process_for(context, pattern, name, seconds):
         f"sh -c \"sleep {seconds} && pkill -CONT -f '{quoted}'\"",
     )
 
-@when('we create a table in container "(?P<name>[a-zA-Z0-9_-]+)" with statement timeout "(?P<timeout_ms>[0-9]+)" ms and expect it does not complete')
+@when('we create a table in container "(?P<name>[a-zA-Z0-9_-]+)" and expect it does not complete within "(?P<timeout_ms>[0-9]+)" ms')
 def step_create_table_expect_timeout(context, name, timeout_ms):
     """
-    Try to CREATE TABLE directly on "name" with a bounded statement_timeout
-    and assert it does NOT complete (neither succeeds nor fails with any error
-    other than a timeout/cancellation) within that time.
+    Try to CREATE TABLE directly on "name" and assert it does NOT complete
+    within the given application-side timeout.
 
-    Used to prove that no sync replica is acknowledging writes to this host
-    (e.g. an old primary during/after a failover). CREATE TABLE is itself the
-    probe write - no prior schema setup is required in the feature file.
+    The deadline is enforced in the test process (not via Postgres
+    statement_timeout): run the query in a helper thread, and on timeout
+    cancel the backend via the connection and treat that as success.
     """
     container = context.containers[name]
+    timeout_sec = int(timeout_ms) / 1000.0
     conn = psycopg2.connect(
         host=helpers.container_get_host(),
         port=helpers.container_get_tcp_port(container, 5432),
         dbname='postgres',
         user='postgres',
-        options=f'-c statement_timeout={timeout_ms}',
     )
     conn.autocommit = True
     start = time.time()
-    try:
+
+    def _create_table():
         with conn.cursor() as cur:
             cur.execute('CREATE TABLE race_probe (ts timestamp)')
-        elapsed = time.time() - start
-        assert False, f'CREATE TABLE unexpectedly completed in {elapsed:.2f}s on container "{name}"'
-    except psycopg2.errors.QueryCanceled:
-        elapsed = time.time() - start
-        helpers.LOG.info(
-            f'CREATE TABLE on container "{name}" correctly did not complete within {elapsed:.2f}s'
-        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_create_table)
+            try:
+                future.result(timeout=timeout_sec)
+            except FuturesTimeoutError:
+                conn.cancel()
+                elapsed = time.time() - start
+                helpers.LOG.info(
+                    f'CREATE TABLE on container "{name}" correctly did not complete within {elapsed:.2f}s'
+                )
+                # Drain the cancelled worker; ignore the resulting DB error.
+                with contextlib.suppress(Exception):
+                    future.result(timeout=5)
+                return
+            elapsed = time.time() - start
+            assert False, f'CREATE TABLE unexpectedly completed in {elapsed:.2f}s on container "{name}"'
     finally:
-        conn.close()
+        with contextlib.suppress(Exception):
+            conn.close()

--- a/tests/steps/cluster.py
+++ b/tests/steps/cluster.py
@@ -1318,3 +1318,83 @@ def step_container_pgconsul_log_contains_in_order(context, name, sec):
         name, last_error, attempt,
     )
     raise AssertionError(last_error)
+
+@then('container "(?P<name>[a-zA-Z0-9_-]+)" walreceiver is streaming from container "(?P<primary_name>[a-zA-Z0-9_-]+)"')
+@helpers.retry_on_assert
+def step_walreceiver_streaming_from_container(context, name, primary_name):
+    """
+    Check pg_stat_wal_receiver directly on "name" to confirm it is actively
+    streaming from "primary_name"'s current address.
+
+    This deliberately does not rely on ZK/pgconsul state (e.g. leader lock,
+    replics_info), which can be stale or contradictory mid-failover - it
+    checks the actual Postgres-level replication connection.
+    """
+    container = context.containers[name]
+    db = Postgres(host=helpers.container_get_host(), port=helpers.container_get_tcp_port(container, 5432))
+    stat = db.get_walreceiver_stat()
+    assert stat is not None and stat.get('status') == 'streaming', (
+        f'walreceiver on "{name}" is not streaming (stat: {stat})'
+    )
+    primary_fqdn = helpers.container_get_fqdn(context.containers[primary_name])
+    conninfo = stat.get('conninfo') or ''
+    assert f'host={primary_fqdn}' in conninfo, (
+        f'walreceiver on "{name}" is not streaming from "{primary_fqdn}" (conninfo: {conninfo})'
+    )
+
+@when('we freeze process "(?P<pattern>[^"]+)" in container "(?P<name>[a-zA-Z0-9_-]+)" for "(?P<seconds>[0-9]+)" seconds')
+def step_freeze_process_for(context, pattern, name, seconds):
+    """
+    SIGSTOP a process matching "pattern" (pkill -f) and schedule an automatic
+    SIGCONT after "seconds" in the background.
+
+    Used to hold a process (e.g. postgres startup) frozen for a bounded window
+    without requiring an explicit unfreeze step later in the scenario.
+    """
+    seconds = int(seconds)
+    # Quote pattern for the shell; pattern comes from the feature file, not user input.
+    quoted = pattern.replace("'", "'\\''")
+    code, output = ensure_exec(context, name, f"pkill -STOP -f '{quoted}'")
+    assert code == 0, (
+        f'Failed to SIGSTOP process matching "{pattern}" in container "{name}": {output}'
+    )
+    # Detach so the sleep+CONT outlives this step.
+    ensure_exec_nowait(
+        context,
+        name,
+        f"sh -c \"sleep {seconds} && pkill -CONT -f '{quoted}'\"",
+    )
+
+@when('we create a table in container "(?P<name>[a-zA-Z0-9_-]+)" with statement timeout "(?P<timeout_ms>[0-9]+)" ms and expect it does not complete')
+def step_create_table_expect_timeout(context, name, timeout_ms):
+    """
+    Try to CREATE TABLE directly on "name" with a bounded statement_timeout
+    and assert it does NOT complete (neither succeeds nor fails with any error
+    other than a timeout/cancellation) within that time.
+
+    Used to prove that no sync replica is acknowledging writes to this host
+    (e.g. an old primary during/after a failover). CREATE TABLE is itself the
+    probe write - no prior schema setup is required in the feature file.
+    """
+    container = context.containers[name]
+    conn = psycopg2.connect(
+        host=helpers.container_get_host(),
+        port=helpers.container_get_tcp_port(container, 5432),
+        dbname='postgres',
+        user='postgres',
+        options=f'-c statement_timeout={timeout_ms}',
+    )
+    conn.autocommit = True
+    start = time.time()
+    try:
+        with conn.cursor() as cur:
+            cur.execute('CREATE TABLE race_probe (ts timestamp)')
+        elapsed = time.time() - start
+        assert False, f'CREATE TABLE unexpectedly completed in {elapsed:.2f}s on container "{name}"'
+    except psycopg2.errors.QueryCanceled:
+        elapsed = time.time() - start
+        helpers.LOG.info(
+            f'CREATE TABLE on container "{name}" correctly did not complete within {elapsed:.2f}s'
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Problem

During failover a replica clears `primary_conninfo` and reloads so that it stops receiving WAL from the old primary before it reads LSN and votes. That disable is applied by Postgres **startup asynchronously**. Reload returning does **not** mean walreceiver is already gone.

Until startup actually stops the receiver, the replica can still:
- receive WAL onto disk;
- send sync acknowledgements to the old primary.

`pg_wal_replay_pause()` does not close this window: it only stops **replay**, not receive/ack. So a replica can vote with an LSN taken while walreceiver is still alive, and the resurrected old primary can still get sync commits acknowledged after voting has started — a split-brain / divergent-write risk.

## Fix

Before entering the election:
1. set `primary_conninfo` to empty and reload (if needed);
2. wait until `pg_stat_wal_receiver` is empty, up to `replica.walreceiver_disable_timeout` (default 5s);
3. if the receiver does not stop in time — abort this failover attempt;
4. only then read LSN and participate in the election.

`pg_wal_replay_pause` was removed from this path as ineffective for the problem above.

## Test

New scenario in `failover_with_network_inconsistency.feature` forces the worst case:
- replicas enter failover and hit a debug sleep before disable;
- old primary is started again and walreceivers reconnect;
- replica `postgres: startup` is SIGSTOP’d (auto-CONT after N seconds), so disable cannot take effect while frozen;
- after votes appear in ZK, a sync `CREATE TABLE` on the old primary must **not** complete (app-side deadline; `statement_timeout` does not cancel SyncRep waits).

With the fix, replicas do not vote until the receiver is really stopped (after CONT / successful wait). Without the wait, they can vote while the receiver is still acking and the write can succeed.

Debug-only knobs for the scenario: `debug.pre_pause_sleep`, `debug.election_lsn_read_sleep`.

New scenario green with this change; red if wait-for-stop is removed