### PR TITLE
Stabilize faultstorm test infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,12 @@ faultstorm_build:
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml build --build-arg replication_type=$(REPLICATION_TYPE) --build-arg pg_major=$(PG_MAJOR)
 
 faultstorm_up:
+	docker compose -p $(PROJECT) down --remove-orphans
+	docker network rm $(PROJECT)_net 2>/dev/null || true
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml down --remove-orphans
 	docker image rm faultstorm:latest || true
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml build faultstorm
-	docker compose -p $(PROJECT) -f faultstorm-compose.yml up -d
+	docker compose -p $(PROJECT) -f faultstorm-compose.yml up -d --remove-orphans
 	docker exec pgconsul_postgresql1_1 /usr/local/bin/generate_certs.sh
 	docker exec pgconsul_postgresql2_1 /usr/local/bin/generate_certs.sh
 	docker exec pgconsul_postgresql3_1 /usr/local/bin/generate_certs.sh
@@ -145,7 +147,7 @@ faultstorm_up:
 
 faultstorm_behave:
 	mkdir -p logs
-	pip install --force-reinstall --no-cache-dir --timeout 120 --retries 3 "${FAULTSTORM_REPO}#egg=faultstorm[postgres]"
+	python3 -m pip install --force-reinstall --no-cache-dir --timeout 120 --retries 3 "faultstorm[postgres] @ ${FAULTSTORM_REPO}" behave
 	@failed=0; \
 	if [ -n "$(FAULTSTORM_FEATURE)" ]; then \
 		features="$(FAULTSTORM_FEATURE)"; \
@@ -156,10 +158,13 @@ faultstorm_behave:
 		fname=$$(basename "$$feature" .feature); \
 		logfile=$(CURDIR)/logs/faultstorm_$$fname.log; \
 		echo "=== Running $$feature ==="; \
-		(cd tests/faultstorm && PYTHONPATH=$(CURDIR)/docker/faultstorm PG_MAJOR=$(PG_MAJOR) \
-			python3 -m behave $(CURDIR)/$$feature >$$logfile 2>&1 \
-			&& cat $$logfile) \
-		|| (cat $$logfile; failed=1); \
+		if (cd tests/faultstorm && PYTHONPATH=$(CURDIR)/docker/faultstorm PG_MAJOR=$(PG_MAJOR) \
+			python3 -m behave --tags=-@skip $(CURDIR)/$$feature >$$logfile 2>&1); then \
+			cat $$logfile; \
+		else \
+			cat $$logfile; \
+			failed=1; \
+		fi; \
 		./docker/faultstorm/save_logs.sh $(PG_MAJOR); \
 		docker cp pgconsul_faultstorm_1:/tmp/faultstorm_ops.log logs/faultstorm/faultstorm_ops.log 2>/dev/null || true; \
 		rm -rf logs/behave_$$fname/; \

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ jepsen: build jepsen_test
 FAULTSTORM_REPO=git+https://github.com/munakoiso/faultstorm.git
 export FAULTSTORM_REPO
 
+FAULTSTORM_SESSIONS ?= 12
+FAULTSTORM_SESSION_CYCLES ?= 3
+FAULTSTORM_SESSION_READ_DURATION ?= 10
+
 FAULTSTORM_COMMIT=$(shell git ls-remote $(subst git+,,$(FAULTSTORM_REPO)) HEAD | cut -f1)
 export FAULTSTORM_COMMIT
 
@@ -125,7 +129,7 @@ faultstorm_build:
 	docker build -t pgconsulbase:latest . --label pgconsul_tests
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml build --build-arg replication_type=$(REPLICATION_TYPE) --build-arg pg_major=$(PG_MAJOR)
 
-faultstorm_up:
+faultstorm_up: faultstorm_build
 	docker compose -p $(PROJECT) down --remove-orphans
 	docker network rm $(PROJECT)_net 2>/dev/null || true
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml down --remove-orphans
@@ -178,7 +182,7 @@ faultstorm_behave:
 	exit $$failed
 
 faultstorm_test:
-	(docker exec pgconsul_faultstorm_1 python3 /root/main.py >logs/faultstorm.log 2>&1 && cat logs/faultstorm.log && ./docker/faultstorm/save_logs.sh ${PG_MAJOR}) || (./docker/faultstorm/save_logs.sh ${PG_MAJOR} && cat logs/faultstorm.log && exit 1)
+	(docker exec pgconsul_faultstorm_1 python3 /root/main.py --sessions $(FAULTSTORM_SESSIONS) --fault-cycles $(FAULTSTORM_SESSION_CYCLES) --read-duration $(FAULTSTORM_SESSION_READ_DURATION) >logs/faultstorm.log 2>&1 && cat logs/faultstorm.log && ./docker/faultstorm/save_logs.sh ${PG_MAJOR}) || (./docker/faultstorm/save_logs.sh ${PG_MAJOR} && cat logs/faultstorm.log && exit 1)
 
 faultstorm_cleanup:
 	docker compose -p $(PROJECT) -f faultstorm-compose.yml down --rmi all

--- a/docker/faultstorm/Dockerfile
+++ b/docker/faultstorm/Dockerfile
@@ -18,7 +18,7 @@ RUN cp /var/lib/dist/test_ssh_key /root/.ssh/id_rsa && \
     rm -rf /var/lib/apt/lists/*
 # Cache-bust: when FAULTSTORM_COMMIT changes, pip install is re-run
 ARG FAULTSTORM_COMMIT=unknown
-RUN pip3 install --timeout 120 --retries 3 "${FAULTSTORM_REPO}#egg=faultstorm[postgres]"
+RUN pip3 install --timeout 120 --retries 3 "faultstorm[postgres] @ ${FAULTSTORM_REPO}"
 COPY main.py /root/main.py
 COPY load_worker.py /root/load_worker.py
 COPY faultstorm_config.py /root/faultstorm_config.py

--- a/docker/faultstorm/main.py
+++ b/docker/faultstorm/main.py
@@ -5,8 +5,10 @@ Configures pgconsul-specific cluster settings, creates a PgConsulClient,
 registers built-in fault actions, and runs the test via TestRunner.
 """
 
-import sys
 import logging
+import os
+import sys
+from typing import Callable
 
 from faultstorm_config import get_default_config, get_quick_config
 from faultstorm_config import create_pgconsul_registry, build_pgconsul_dc_map
@@ -19,6 +21,41 @@ logging.basicConfig(
     format='%(asctime)s %(levelname)s %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+def _cleanup_successful_session(config, db_client) -> None:  # type: ignore[no-untyped-def]
+    """Clear data and transient logs after a validated session."""
+    last_error = None
+    for node in config.db_nodes:
+        try:
+            db_client.setup(node)
+            break
+        except Exception as exc:
+            last_error = exc
+    else:
+        raise RuntimeError("Could not clear the test table after a successful session") from last_error
+
+    for path in (config.operations_log, config.scenario_log):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def _run_sessions(config, db_client, registry, dc_map, sessions: int, runner_factory: Callable = TestRunner) -> bool:  # type: ignore[no-untyped-def]
+    """Run bounded sessions and retain logs only for the first failed one."""
+    for session in range(1, sessions + 1):
+        logger.info("Starting faultstorm session %d/%d", session, sessions)
+        runner = runner_factory(config, db_client, registry, dc_map=dc_map)
+        result = runner.run()
+        if not result.valid:
+            logger.error("Faultstorm session %d/%d failed; retaining its logs", session, sessions)
+            return False
+
+        _cleanup_successful_session(config, db_client)
+        logger.info("Faultstorm session %d/%d passed and was cleaned up", session, sessions)
+
+    return True
 
 
 def main() -> None:
@@ -43,6 +80,18 @@ def main() -> None:
         '--read-duration',
         type=int,
         help='Read phase duration in seconds',
+    )
+    parser.add_argument(
+        '--sessions',
+        type=int,
+        default=1,
+        help='Number of independent fault sessions to run',
+    )
+    parser.add_argument(
+        '--fault-cycles',
+        type=int,
+        default=None,
+        help='Random fault cycles per session',
     )
     parser.add_argument(
         '--replay-scenario',
@@ -70,6 +119,14 @@ def main() -> None:
         config.write_phase_duration = args.write_duration
     if args.read_duration:
         config.read_phase_duration = args.read_duration
+    elif not args.replay_scenario:
+        config.read_phase_duration = 10
+
+    if args.sessions < 1 or args.fault_cycles is not None and args.fault_cycles < 1:
+        parser.error('--sessions and --fault-cycles must be positive')
+
+    if args.fault_cycles is not None and not args.replay_scenario and not args.write_duration:
+        config.write_phase_duration = args.fault_cycles * (config.fault_active_duration + config.fault_pause_duration)
 
     # Override scenario options
     if args.replay_scenario:
@@ -88,9 +145,9 @@ def main() -> None:
 
     logger.info("DC map: %s", dc_map)
 
-    # Run test
-    runner = TestRunner(config, db_client, registry, dc_map=dc_map)
-    passed = runner.run_and_print()
+    # Run bounded sessions. A failed session keeps its logs for diagnostics;
+    # a successful session is independent of the next one.
+    passed = _run_sessions(config, db_client, registry, dc_map, args.sessions)
 
     # Exit with appropriate code
     sys.exit(0 if passed else 1)

--- a/docker/pgconsul/Dockerfile
+++ b/docker/pgconsul/Dockerfile
@@ -49,6 +49,8 @@ RUN pg_dropcluster --stop $PG_MAJOR main && \
     cp /var/lib/dist/docker/pgconsul/userlist.txt /etc/pgbouncer/userlist.txt && \
     cp /var/lib/dist/docker/pgconsul/sudoers /etc/sudoers.d/pgconsul && \
     cp /var/lib/dist/docker/pgconsul/setup.sh /usr/local/bin/setup.sh && \
+    cp /var/lib/dist/tests/conf/cleanup_stale_postmaster_pid.sh /usr/local/bin/cleanup_stale_postmaster_pid.sh && \
+    chmod 755 /usr/local/bin/cleanup_stale_postmaster_pid.sh && \
     cp /var/lib/dist/docker/pgconsul/pg_resetup.py /usr/local/bin/pg_resetup.py && \
     cp /var/lib/dist/docker/pgconsul/archive.passwd /etc/archive.passwd && \
     chown postgres:postgres /etc/archive.passwd && \

--- a/docker/pgconsul/postgresql.conf
+++ b/docker/pgconsul/postgresql.conf
@@ -10,7 +10,6 @@ log_min_messages = debug5
 log_line_prefix = '%t [%p-%l] %q%u@%d '
 log_timezone = 'UTC'
 log_hostname = on
-stats_temp_directory = '/var/run/postgresql/pg_stat_tmp'
 datestyle = 'iso, mdy'
 timezone = 'UTC'
 lc_messages = 'C'

--- a/tests/faultstorm/environment.py
+++ b/tests/faultstorm/environment.py
@@ -31,6 +31,7 @@ if FAULTSTORM_DIR not in sys.path:
 
 from faultstorm.cluster import ClusterManager  # noqa: E402
 from faultstorm.network_latency import NetworkLatencyManager  # noqa: E402
+from steps.common import wait_for_healthy_cluster  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,14 @@ def before_all(context):
         "dc2": ["postgresql2", "zookeeper2"],
         "dc3": ["postgresql3", "zookeeper3"],
     }
+
+
+def before_feature(context, feature):
+    """Do not start a feature while the preceding one is still recovering."""
+    if "docker" not in feature.tags or "skip" in feature.tags:
+        return
+    logger.info("Waiting for the cluster to recover before feature %s", feature.name)
+    wait_for_healthy_cluster(context.db_nodes)
 
 
 def after_scenario(context, scenario):

--- a/tests/faultstorm/features/actions.feature
+++ b/tests/faultstorm/features/actions.feature
@@ -30,6 +30,7 @@ Feature: Pgconsul-specific actions
     Then the switchover action node is one of the db nodes
     When I wait up to 180 seconds for the primary to change
     Then the primary has changed
+    And I wait up to 180 seconds for the cluster to recover
 
   @docker
   Scenario: Maintenance enable and heal (disable) verifiable via pgconsul-util

--- a/tests/faultstorm/steps/common.py
+++ b/tests/faultstorm/steps/common.py
@@ -1,5 +1,7 @@
 """Shared helpers for faultstorm step definitions."""
 
+import time
+
 from faultstorm.cluster import ClusterManager
 
 
@@ -21,3 +23,40 @@ def find_primary(db_nodes):
         except Exception:
             continue
     return None
+
+
+def get_cluster_roles(db_nodes):
+    """Return PostgreSQL recovery roles for every node, or ``None``."""
+    roles = {}
+    for node in db_nodes:
+        try:
+            out = ClusterManager.exec_on_node(
+                node,
+                ["sudo", "-u", "postgres", "psql", "-tAc",
+                 "SELECT pg_is_in_recovery()"],
+                timeout=5,
+            ).strip()
+        except Exception:
+            return None
+        if out not in ("t", "f"):
+            return None
+        roles[node] = out
+    return roles
+
+
+def wait_for_healthy_cluster(db_nodes, timeout=180):
+    """Wait until every node accepts SQL and exactly one is primary."""
+    deadline = time.time() + timeout
+    last_roles = None
+    while time.time() < deadline:
+        roles = get_cluster_roles(db_nodes)
+        if roles is not None:
+            last_roles = roles
+            if list(roles.values()).count("f") == 1 and list(roles.values()).count("t") == len(db_nodes) - 1:
+                return roles
+        time.sleep(2)
+    raise AssertionError(
+        "Cluster did not recover within {}s; last PostgreSQL roles: {}".format(
+            timeout, last_roles,
+        )
+    )

--- a/tests/faultstorm/steps/switchover_steps.py
+++ b/tests/faultstorm/steps/switchover_steps.py
@@ -6,7 +6,7 @@ from behave import given, when, then
 
 from faultstorm_switchover import SwitchoverAction
 
-from steps.common import find_primary
+from steps.common import find_primary, wait_for_healthy_cluster
 
 
 @given('a switchover action with no node')
@@ -54,3 +54,8 @@ def step_primary_changed(context):
     assert context.new_primary != context.original_primary, (
         f"Primary did not change: still {context.original_primary}"
     )
+
+
+@then('I wait up to {seconds:d} seconds for the cluster to recover')
+def step_wait_cluster_recovery(context, seconds):
+    context.cluster_roles = wait_for_healthy_cluster(context.db_nodes, timeout=seconds)


### PR DESCRIPTION
Fixes faultstorm setup and feature isolation.

- remove the obsolete PostgreSQL setting from the test image
- install faultstorm with current pip syntax
- clean conflicting compose networks before faultstorm startup
- make Behave skip @skip and propagate failures
- wait for normal cluster recovery between faultstorm features